### PR TITLE
use shorthand for npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "build/index.js",
   "scripts": {
     "prepublish": "npm run build",
-    "build": "./node_modules/babel/bin/babel/index.js lib -d build",
-    "test": "./node_modules/mocha/bin/mocha --compilers js:babel/register"
+    "build": "babel lib -d build",
+    "test": "_mocha --compilers js:babel/register"
   },
   "keywords": [
     "music",


### PR DESCRIPTION
fixes #4 

This removes the build dir before rather than after. Not sure if you want to ignore the build dir or put it in git, but this fixed the issue I was having. Also for simplicity I made `babel` and `_mocha` shorter since npm scripts knows about `node_modules/.bin`.  
