### PR TITLE
Add to CHORDS catalog: dominantSevenFlatNine, dominantSevenSharpNine, dominantSevenFlatFive, dominantSevenSharpFive, dom

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -221,7 +221,7 @@ harmony, jazz, and modal mixture.
 
 No dependencies. Can ship immediately.
 
-- [ ] Add to `CHORDS` catalog: `dominantSevenFlatNine`, `dominantSevenSharpNine`,
+- [x] Add to `CHORDS` catalog: `dominantSevenFlatNine`, `dominantSevenSharpNine`,
       `dominantSevenFlatFive`, `dominantSevenSharpFive`, `dominantSevenSharpEleven`,
       `dominantSevenFlatThirteen`
 - [ ] Add `dominantNineFlatFive`, `dominantNineSharpFive` (9th chords with altered fifths)

--- a/src/chord.test.ts
+++ b/src/chord.test.ts
@@ -3,6 +3,63 @@ import { describe, expect, it } from 'bun:test';
 import { Chord } from './chord.ts';
 import { Note } from './note.ts';
 
+const alteredDominantSeventhCases = [
+  {
+    suffix: 'dominantSevenFlatNine',
+    symbol: '7♭9',
+    asciiSymbol: '7b9',
+    alias: 'sevenFlatNine',
+    notes: ['C4', 'E4', 'G4', 'Bb4', 'Db5'],
+    transposedName: 'D7♭9',
+    firstInversionName: 'C7♭9/E',
+  },
+  {
+    suffix: 'dominantSevenSharpNine',
+    symbol: '7♯9',
+    asciiSymbol: '7#9',
+    alias: 'sevenSharpNine',
+    notes: ['C4', 'E4', 'G4', 'Bb4', 'D#5'],
+    transposedName: 'D7♯9',
+    firstInversionName: 'C7♯9/E',
+  },
+  {
+    suffix: 'dominantSevenFlatFive',
+    symbol: '7♭5',
+    asciiSymbol: '7b5',
+    alias: 'sevenFlatFive',
+    notes: ['C4', 'E4', 'Gb4', 'Bb4'],
+    transposedName: 'D7♭5',
+    firstInversionName: 'C7♭5/E',
+  },
+  {
+    suffix: 'dominantSevenSharpFive',
+    symbol: '7♯5',
+    asciiSymbol: '7#5',
+    alias: 'sevenSharpFive',
+    notes: ['C4', 'E4', 'G#4', 'Bb4'],
+    transposedName: 'D7♯5',
+    firstInversionName: 'C7♯5/E',
+  },
+  {
+    suffix: 'dominantSevenSharpEleven',
+    symbol: '7♯11',
+    asciiSymbol: '7#11',
+    alias: 'sevenSharpEleven',
+    notes: ['C4', 'E4', 'G4', 'Bb4', 'D5', 'F#5'],
+    transposedName: 'D7♯11',
+    firstInversionName: 'C7♯11/E',
+  },
+  {
+    suffix: 'dominantSevenFlatThirteen',
+    symbol: '7♭13',
+    asciiSymbol: '7b13',
+    alias: 'sevenFlatThirteen',
+    notes: ['C4', 'E4', 'G4', 'Bb4', 'D5', 'F5', 'Ab5'],
+    transposedName: 'D7♭13',
+    firstInversionName: 'C7♭13/E',
+  },
+] as const;
+
 describe('Chord', () => {
   it('creates chords from symbols, suffixes, and serialized input', () => {
     const chord = Chord.create('C4', 'maj7');
@@ -69,6 +126,29 @@ describe('Chord', () => {
     expect(() => Chord.create('C4', 'major').inversion(3)).toThrow(RangeError);
     expect(() => Chord.create('C4', 'major').inversion(3)).toThrow(/cannot set inversion/i);
   });
+
+  it.each(alteredDominantSeventhCases)(
+    'supports altered dominant seventh catalog entry $suffix',
+    ({ suffix, symbol, asciiSymbol, alias, notes, transposedName, firstInversionName }) => {
+      const chord = Chord.create('C4', suffix);
+
+      expect(chord.suffix).toBe(suffix);
+      expect(chord.symbol).toBe(symbol);
+      expect(chord.name).toBe(`C${symbol}`);
+      expect(chord.quality).toBe('altered');
+      expect(chord.notes.map((note) => note.toString())).toEqual(notes);
+
+      expect(Chord.create('C4', symbol).suffix).toBe(suffix);
+      expect(Chord.create('C4', asciiSymbol).suffix).toBe(suffix);
+      expect(Chord.create('C4', alias).suffix).toBe(suffix);
+
+      expect(chord.transpose('majorSecond').name).toBe(transposedName);
+      const firstInversion = chord.invert();
+      expect(firstInversion.inversionIndex).toBe(1);
+      expect(firstInversion.bass.toString()).toBe('E4');
+      expect(firstInversion.name).toBe(firstInversionName);
+    },
+  );
 
   it('supports slash chords and catalog-backed interval edits', () => {
     const chord = Chord.create('C4', 'maj7');

--- a/src/chords.ts
+++ b/src/chords.ts
@@ -19,7 +19,18 @@ export const CHORD_SYMBOLS = [
   'mMaj7',
   'dim7',
   'm7b5',
+  '7♭9',
+  '7b9',
+  '7♯9',
+  '7#9',
+  '7♭5',
+  '7b5',
+  '7♯5',
   '7#5',
+  '7♯11',
+  '7#11',
+  '7♭13',
+  '7b13',
   'maj7#5',
   '9',
   'maj9',
@@ -68,6 +79,12 @@ export type CanonicalChordSuffix =
   | 'halfDiminishedSeventh'
   | 'augmentedSeventh'
   | 'augmentedMajorSeventh'
+  | 'dominantSevenFlatNine'
+  | 'dominantSevenSharpNine'
+  | 'dominantSevenFlatFive'
+  | 'dominantSevenSharpFive'
+  | 'dominantSevenSharpEleven'
+  | 'dominantSevenFlatThirteen'
   | 'dominantNinth'
   | 'majorNinth'
   | 'minorNinth'
@@ -98,7 +115,18 @@ type ChordAliasKey =
   | 'min7'
   | 'minorMaj7'
   | 'minorSevenFlatFive'
+  | 'sevenFlatNine'
+  | '7b9'
+  | 'sevenSharpNine'
+  | '7#9'
+  | 'sevenFlatFive'
+  | '7b5'
   | 'sevenSharpFive'
+  | '7#5'
+  | 'sevenSharpEleven'
+  | '7#11'
+  | 'sevenFlatThirteen'
+  | '7b13'
   | 'majorSevenSharpFive'
   | 'nine'
   | 'maj9'
@@ -247,6 +275,45 @@ const CANONICAL_CHORDS: Record<CanonicalChordSuffix, ChordInformation> = {
     symbol: 'maj7#5',
     intervals: ['perfectUnison', 'majorThird', 'augmentedFifth', 'majorSeventh'],
   },
+  dominantSevenFlatNine: {
+    symbol: '7♭9',
+    intervals: ['perfectUnison', 'majorThird', 'perfectFifth', 'minorSeventh', 'minorNinth'],
+  },
+  dominantSevenSharpNine: {
+    symbol: '7♯9',
+    intervals: ['perfectUnison', 'majorThird', 'perfectFifth', 'minorSeventh', 'augmentedNinth'],
+  },
+  dominantSevenFlatFive: {
+    symbol: '7♭5',
+    intervals: ['perfectUnison', 'majorThird', 'diminishedFifth', 'minorSeventh'],
+  },
+  dominantSevenSharpFive: {
+    symbol: '7♯5',
+    intervals: ['perfectUnison', 'majorThird', 'augmentedFifth', 'minorSeventh'],
+  },
+  dominantSevenSharpEleven: {
+    symbol: '7♯11',
+    intervals: [
+      'perfectUnison',
+      'majorThird',
+      'perfectFifth',
+      'minorSeventh',
+      'majorNinth',
+      'augmentedEleventh',
+    ],
+  },
+  dominantSevenFlatThirteen: {
+    symbol: '7♭13',
+    intervals: [
+      'perfectUnison',
+      'majorThird',
+      'perfectFifth',
+      'minorSeventh',
+      'majorNinth',
+      'perfectEleventh',
+      'minorThirteenth',
+    ],
+  },
   dominantNinth: {
     symbol: '9',
     intervals: ['perfectUnison', 'majorThird', 'perfectFifth', 'minorSeventh', 'majorNinth'],
@@ -356,7 +423,18 @@ const CHORD_ALIASES: Record<ChordAliasKey, CanonicalChordSuffix> = {
   min7: 'minorSeventh',
   minorMaj7: 'minorMajorSeventh',
   minorSevenFlatFive: 'halfDiminishedSeventh',
-  sevenSharpFive: 'augmentedSeventh',
+  sevenFlatNine: 'dominantSevenFlatNine',
+  '7b9': 'dominantSevenFlatNine',
+  sevenSharpNine: 'dominantSevenSharpNine',
+  '7#9': 'dominantSevenSharpNine',
+  sevenFlatFive: 'dominantSevenFlatFive',
+  '7b5': 'dominantSevenFlatFive',
+  sevenSharpFive: 'dominantSevenSharpFive',
+  '7#5': 'dominantSevenSharpFive',
+  sevenSharpEleven: 'dominantSevenSharpEleven',
+  '7#11': 'dominantSevenSharpEleven',
+  sevenFlatThirteen: 'dominantSevenFlatThirteen',
+  '7b13': 'dominantSevenFlatThirteen',
   majorSevenSharpFive: 'augmentedMajorSeventh',
   nine: 'dominantNinth',
   maj9: 'majorNinth',
@@ -389,7 +467,18 @@ export const CHORDS: Readonly<Record<ChordSuffix, ChordInformation>> = Object.fr
   min7: CANONICAL_CHORDS.minorSeventh,
   minorMaj7: CANONICAL_CHORDS.minorMajorSeventh,
   minorSevenFlatFive: CANONICAL_CHORDS.halfDiminishedSeventh,
-  sevenSharpFive: CANONICAL_CHORDS.augmentedSeventh,
+  sevenFlatNine: CANONICAL_CHORDS.dominantSevenFlatNine,
+  '7b9': CANONICAL_CHORDS.dominantSevenFlatNine,
+  sevenSharpNine: CANONICAL_CHORDS.dominantSevenSharpNine,
+  '7#9': CANONICAL_CHORDS.dominantSevenSharpNine,
+  sevenFlatFive: CANONICAL_CHORDS.dominantSevenFlatFive,
+  '7b5': CANONICAL_CHORDS.dominantSevenFlatFive,
+  sevenSharpFive: CANONICAL_CHORDS.dominantSevenSharpFive,
+  '7#5': CANONICAL_CHORDS.dominantSevenSharpFive,
+  sevenSharpEleven: CANONICAL_CHORDS.dominantSevenSharpEleven,
+  '7#11': CANONICAL_CHORDS.dominantSevenSharpEleven,
+  sevenFlatThirteen: CANONICAL_CHORDS.dominantSevenFlatThirteen,
+  '7b13': CANONICAL_CHORDS.dominantSevenFlatThirteen,
   majorSevenSharpFive: CANONICAL_CHORDS.augmentedMajorSeventh,
   nine: CANONICAL_CHORDS.dominantNinth,
   maj9: CANONICAL_CHORDS.majorNinth,
@@ -446,6 +535,12 @@ const CHORD_QUALITY_BY_SUFFIX: Record<CanonicalChordSuffix, ChordQuality> = {
   suspendedSecond: 'suspended',
   suspendedFourth: 'suspended',
   dominantSeventh: 'dominant',
+  dominantSevenFlatNine: 'altered',
+  dominantSevenSharpNine: 'altered',
+  dominantSevenFlatFive: 'altered',
+  dominantSevenSharpFive: 'altered',
+  dominantSevenSharpEleven: 'altered',
+  dominantSevenFlatThirteen: 'altered',
   dominantNinth: 'dominant',
   dominantEleventh: 'dominant',
   dominantThirteenth: 'dominant',


### PR DESCRIPTION
## Summary

Add to `CHORDS` catalog: `dominantSevenFlatNine`, `dominantSevenSharpNine`, `dominantSevenFlatFive`, `dominantSevenSharpFive`, `dominantSevenSharpEleven`, `dominantSevenFlatThirteen`

Automated by ralph-pipeline.

## Test plan

- CI checks pass
- Review bot feedback addressed
