### PR TITLE
fix: address Copilot review feedback on Wave A (PR #39)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"cda2a2a9-dcc7-4dc5-83f6-9011d1a8162b","pid":67780,"procStart":"Sat Jun  6 22:51:39 2026","acquiredAt":1780787418833}

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ repomix-output.xml
 .env.*.local
 tmp/
 /.claude/worktrees
+/.claude/scheduled_tasks.lock

--- a/src/piano-keyboard.test.ts
+++ b/src/piano-keyboard.test.ts
@@ -356,8 +356,7 @@ describe('highlightGroupsForChordOrScale', () => {
   });
 
   it('normalizes out-of-range pitch-class numbers into 0..11', () => {
-    // Negative and >=12 inputs must wrap, not throw. JS `%` is sign-preserving,
-    // so -1 % 12 === -1; the implementation normalizes via ((n % 12) + 12) % 12.
+    // Negative and >=12 pitch-class numbers must wrap into 0..11, not throw.
     expect(highlightGroupsForChordOrScale(-1, range)[0]?.chromaticIndex).toBe(11); // -1 → B
     expect(highlightGroupsForChordOrScale(12, range)[0]?.chromaticIndex).toBe(0); // 12 → C
     expect(highlightGroupsForChordOrScale(13, range)[0]?.chromaticIndex).toBe(1); // 13 → C#

--- a/src/piano-keyboard.test.ts
+++ b/src/piano-keyboard.test.ts
@@ -355,6 +355,15 @@ describe('highlightGroupsForChordOrScale', () => {
     expect(groups[0]?.chromaticIndex).toBe(0);
   });
 
+  it('normalizes out-of-range pitch-class numbers into 0..11', () => {
+    // Negative and >=12 inputs must wrap, not throw. JS `%` is sign-preserving,
+    // so -1 % 12 === -1; the implementation normalizes via ((n % 12) + 12) % 12.
+    expect(highlightGroupsForChordOrScale(-1, range)[0]?.chromaticIndex).toBe(11); // -1 → B
+    expect(highlightGroupsForChordOrScale(12, range)[0]?.chromaticIndex).toBe(0); // 12 → C
+    expect(highlightGroupsForChordOrScale(13, range)[0]?.chromaticIndex).toBe(1); // 13 → C#
+    expect(highlightGroupsForChordOrScale(-13, range)[0]?.chromaticIndex).toBe(11); // -13 → B
+  });
+
   it('omits groups whose pitch class is not in the range', () => {
     // Use a tiny range (C4 only) and a chord with notes outside the range
     const tinyRange = keyboardRange(60, 60); // only C4

--- a/src/piano-keyboard.ts
+++ b/src/piano-keyboard.ts
@@ -321,8 +321,10 @@ function chromaticIndexesForTarget(target: HighlightTarget): readonly ChromaticI
   }
 
   if (typeof target === 'number') {
-    // treat as a pitch-class number (0..11)
-    return Object.freeze([createChromaticIndex(target % 12)]);
+    // Treat as a pitch-class number. Normalize into 0..11 first: JS `%` is
+    // sign-preserving (e.g. `-1 % 12 === -1`), so a bare modulo would throw
+    // for negative inputs. `((n % 12) + 12) % 12` maps any integer to 0..11.
+    return Object.freeze([createChromaticIndex(((target % 12) + 12) % 12)]);
   }
 
   // NoteLike / Note

--- a/src/piano-keyboard.ts
+++ b/src/piano-keyboard.ts
@@ -7,6 +7,7 @@ import {
 } from './branded-types.js';
 import { Chord } from './chord.js';
 import { Note, type NoteLike } from './note.js';
+import { normalizeChromaticIndex } from './note-spellings.js';
 import { Scale } from './scale.js';
 
 /**
@@ -321,10 +322,10 @@ function chromaticIndexesForTarget(target: HighlightTarget): readonly ChromaticI
   }
 
   if (typeof target === 'number') {
-    // Treat as a pitch-class number. Normalize into 0..11 first: JS `%` is
-    // sign-preserving (e.g. `-1 % 12 === -1`), so a bare modulo would throw
-    // for negative inputs. `((n % 12) + 12) % 12` maps any integer to 0..11.
-    return Object.freeze([createChromaticIndex(((target % 12) + 12) % 12)]);
+    // Treat as a pitch-class number, normalized into 0..11. Reuse the shared
+    // helper so any integer (including negatives, where JS `%` is
+    // sign-preserving) maps consistently with the rest of the library.
+    return Object.freeze([normalizeChromaticIndex(target)]);
   }
 
   // NoteLike / Note

--- a/src/rhythm.ts
+++ b/src/rhythm.ts
@@ -85,12 +85,9 @@ export type GridPosition = {
   /** The duration of this event. */
   readonly duration: Duration;
   /**
-   * The grid position (zero-based) this onset falls on, measured in the grid
-   * unit used to build it: `onset / subdivision`, where `subdivision` is the
-   * value passed to {@link RhythmPattern.subdivisionGrid} (defaulting to the
-   * meter's beat unit). With the default subdivision this is the beat number;
-   * with a custom subdivision it counts that subdivision instead. Fractional
-   * when the onset falls between grid positions.
+   * The zero-based position in the grid used to build this event. Defaults to
+   * the beat number when using the meter's beat unit; a custom subdivision
+   * counts that subdivision instead. Fractional when between grid positions.
    */
   readonly beatPosition: Rational;
 };

--- a/src/rhythm.ts
+++ b/src/rhythm.ts
@@ -85,8 +85,12 @@ export type GridPosition = {
   /** The duration of this event. */
   readonly duration: Duration;
   /**
-   * The beat number (zero-based) this onset falls on, measured in beat units of the meter.
-   * Fractional when the onset is between beats.
+   * The grid position (zero-based) this onset falls on, measured in the grid
+   * unit used to build it: `onset / subdivision`, where `subdivision` is the
+   * value passed to {@link RhythmPattern.subdivisionGrid} (defaulting to the
+   * meter's beat unit). With the default subdivision this is the beat number;
+   * with a custom subdivision it counts that subdivision instead. Fractional
+   * when the onset falls between grid positions.
    */
   readonly beatPosition: Rational;
 };


### PR DESCRIPTION
## Summary

Follow-up to #39, addressing the three Copilot review comments that landed on that PR after it merged. (My miss — I merged #39 on green CI without re-checking the bot's review comments.)

1. **`piano-keyboard.ts` — real correctness bug.** `highlightGroupsForChordOrScale(n)` with a negative pitch-class number threw, because JS `%` is sign-preserving (`-1 % 12 === -1`) and `createChromaticIndex(-1)` rejects it. Now normalized via the existing exported `normalizeChromaticIndex` helper (which does `((n % 12) + 12) % 12` then validates) — fixes the bug and removes the duplicated inline formula. Regression test added covering -1, 12, 13, -13.
2. **`rhythm.ts` — `GridPosition.beatPosition` docstring.** It claimed the value is measured in the meter's beat units, but `subdivisionGrid(meter, subdivision?)` divides by the passed `subdivision`. Docstring corrected (and kept concise) to note it counts the grid unit used to build it.
3. **chore — removed accidentally-committed `.claude/scheduled_tasks.lock`** (an ephemeral session lockfile) and added a `.gitignore` rule so it can't be reintroduced.

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, simplicity-engineer (all via Codex medium-effort fallback — Claude `Agent` dispatch hit the known `/usage-credits` error), plus:
- Codex (gpt-5.4, xhigh reasoning) — 1 round, APPROVED
- 1 round of review; all must-fix items addressed (simplicity-engineer's "reuse `normalizeChromaticIndex`" must-fix verified against the actual helper and applied)

## Test plan

- `bun run validate` green; 1464 tests pass; `piano-keyboard.ts` and `rhythm.ts` both 100% covered (non-parallel `bun test --coverage`).
- New regression test asserts negative/over-range pitch-class numbers wrap into 0..11 instead of throwing.