### PR TITLE
feat: octavian/sequences subpath + subpath-export foundation (#34, #30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,12 @@
       "import": "./dist/browser/index.js",
       "default": "./dist/browser/index.js"
     },
+    "./sequences": {
+      "types": "./dist/sequences/index.d.ts",
+      "browser": "./dist/browser/sequences/index.js",
+      "import": "./dist/browser/sequences/index.js",
+      "default": "./dist/browser/sequences/index.js"
+    },
     "./package.json": "./package.json"
   },
   "types": "./dist/index.d.ts",

--- a/scripts/smoke-checks.mjs
+++ b/scripts/smoke-checks.mjs
@@ -24,3 +24,21 @@ export function assertSmokeChecks(octavian) {
     throw new Error('INTERVALS catalog broken');
   }
 }
+
+// Subpath-export smoke checks. Each subpath (e.g. octavian/sequences) is a
+// separate entry in the package.json "exports" map and resolves to its own
+// browser bundle. When adding a new subpath, import it in
+// smoke-consumer-check.mjs and add an assertion here.
+export function assertSequencesSmokeChecks(sequences) {
+  if (typeof sequences.Sequence?.create !== 'function') {
+    throw new Error('octavian/sequences: Sequence.create missing');
+  }
+  if (typeof sequences.musicalTime !== 'function') {
+    throw new Error('octavian/sequences: musicalTime missing');
+  }
+  const seq = sequences.Sequence.create(
+    [{ type: 'rest', start: sequences.musicalTime(0, 1), duration: sequences.musicalTime(1, 4) }],
+    { tempo: 120 },
+  );
+  if (seq.events.length !== 1) throw new Error('octavian/sequences: Sequence.create broken');
+}

--- a/scripts/smoke-checks.mjs
+++ b/scripts/smoke-checks.mjs
@@ -29,6 +29,15 @@ export function assertSmokeChecks(octavian) {
 // separate entry in the package.json "exports" map and resolves to its own
 // browser bundle. When adding a new subpath, import it in
 // smoke-consumer-check.mjs and add an assertion here.
+//
+// The tarball smoke test runs under Bun (a non-browser runtime). For pure
+// subpaths, exercise real behavior as below. For browser-only ADAPTER subpaths
+// (Web Audio, Web MIDI), the runtime globals (AudioContext,
+// navigator.requestMIDIAccess) do not exist here — so:
+//   1. The adapter module MUST NOT touch browser globals at import time, or the
+//      bare `await import('octavian/<adapter>')` will throw in this test.
+//   2. The assertion must be EXISTENCE-ONLY (`typeof X === 'function'`). Never
+//      instantiate or call an adapter that needs a browser global.
 export function assertSequencesSmokeChecks(sequences) {
   if (typeof sequences.Sequence?.create !== 'function') {
     throw new Error('octavian/sequences: Sequence.create missing');

--- a/scripts/smoke-consumer-check.mjs
+++ b/scripts/smoke-consumer-check.mjs
@@ -2,8 +2,13 @@
 // project alongside _smoke-checks.mjs and executed via bun. Imports the package
 // by name so resolution goes through the consumer's node_modules (exercises the
 // exports map). Assertions live in _smoke-checks.mjs — single source of truth.
-import { assertSmokeChecks } from './_smoke-checks.mjs';
+import { assertSmokeChecks, assertSequencesSmokeChecks } from './_smoke-checks.mjs';
 
 const octavian = await import('octavian');
 assertSmokeChecks(octavian);
+
+// Resolve the octavian/sequences subpath through the consumer's exports map.
+const sequences = await import('octavian/sequences');
+assertSequencesSmokeChecks(sequences);
+
 process.stdout.write('tarball smoke test passed\n');

--- a/scripts/validate-artifacts.ts
+++ b/scripts/validate-artifacts.ts
@@ -16,12 +16,10 @@ type PatternCheck = {
 };
 
 const root = path.resolve(import.meta.dirname, '..');
-const browserArtifactPath = path.join(root, 'dist/browser/index.js');
-const declarationsPath = path.join(root, 'dist/index.d.ts');
+const browserDir = path.join(root, 'dist/browser');
+const distDir = path.join(root, 'dist');
 const packageJsonPath = path.join(root, 'package.json');
 
-const browserArtifact = await fs.readFile(browserArtifactPath, 'utf8');
-const declarationsArtifact = await fs.readFile(declarationsPath, 'utf8');
 const rawPackageJson: unknown = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
 if (!isPackageJson(rawPackageJson)) {
   throw new TypeError('package.json is not a valid object');
@@ -97,22 +95,79 @@ function assertEmptyRuntimeDependencies(): void {
   }
 }
 
-assertZeroMatches(
-  'dist/browser/index.js browser-global check',
-  browserArtifact,
-  browserGlobalPatterns,
-);
+/**
+ * Recursively collects all `.js` files under a directory.
+ *
+ * @param dir The directory to search.
+ * @returns Absolute paths to every `.js` file found.
+ */
+async function collectJsFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      const nested = await collectJsFiles(fullPath);
+      results.push(...nested);
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Recursively collects all `.d.ts` files under a directory.
+ *
+ * @param dir The directory to search.
+ * @returns Absolute paths to every `.d.ts` file found.
+ */
+async function collectDtsFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      const nested = await collectDtsFiles(fullPath);
+      results.push(...nested);
+    } else if (entry.isFile() && entry.name.endsWith('.d.ts')) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+// Check all dist/browser/**/*.js for browser-global and bare-specifier violations.
+// This covers both main bundles and shared chunks emitted by the bundler.
+const browserJsFiles = await collectJsFiles(browserDir);
+if (browserJsFiles.length === 0) {
+  failures.push(`No .js files found under dist/browser/ — build may have failed.`);
+}
+
+let totalBrowserBytes = 0;
+for (const jsFile of browserJsFiles) {
+  const relLabel = path.relative(root, jsFile);
+  const source = await fs.readFile(jsFile, 'utf8');
+  totalBrowserBytes += source.length;
+  assertZeroMatches(`${relLabel} browser-global check`, source, browserGlobalPatterns);
+  assertZeroMatches(`${relLabel} bare-specifier check`, source, bareSpecifierPatterns);
+}
+
 assertEmptyRuntimeDependencies();
-assertZeroMatches(
-  'dist/browser/index.js bare-specifier check',
-  browserArtifact,
-  bareSpecifierPatterns,
-);
-assertZeroMatches(
-  'dist/index.d.ts bare-specifier check',
-  declarationsArtifact,
-  bareSpecifierPatterns,
-);
+
+// Check all dist/**/*.d.ts for bare-specifier violations.
+const dtsFiles = await collectDtsFiles(distDir);
+for (const dtsFile of dtsFiles) {
+  const relLabel = path.relative(root, dtsFile);
+  const source = await fs.readFile(dtsFile, 'utf8');
+  assertZeroMatches(`${relLabel} bare-specifier check`, source, bareSpecifierPatterns);
+}
 
 // Behavioral smoke test. If this script runs under Bun, `node` in PATH may be
 // Bun's shim rather than a real Node binary. Prefer an explicit override and
@@ -189,4 +244,6 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-process.stdout.write(`Artifact validation passed. Bundle size: ${browserArtifact.length} bytes\n`);
+process.stdout.write(
+  `Artifact validation passed. Total browser bundle size: ${totalBrowserBytes} bytes across ${browserJsFiles.length} file(s)\n`,
+);

--- a/scripts/validate-artifacts.ts
+++ b/scripts/validate-artifacts.ts
@@ -96,12 +96,14 @@ function assertEmptyRuntimeDependencies(): void {
 }
 
 /**
- * Recursively collects all `.js` files under a directory.
+ * Recursively collects all files under a directory whose name ends with the
+ * given extension.
  *
  * @param dir The directory to search.
- * @returns Absolute paths to every `.js` file found.
+ * @param extension The file extension to match (e.g. `.js` or `.d.ts`).
+ * @returns Absolute paths to every matching file found.
  */
-async function collectJsFiles(dir: string): Promise<string[]> {
+async function collectFiles(dir: string, extension: string): Promise<string[]> {
   const results: string[] = [];
   const entries = await fs.readdir(dir, { withFileTypes: true });
 
@@ -109,33 +111,9 @@ async function collectJsFiles(dir: string): Promise<string[]> {
     const fullPath = path.join(dir, entry.name);
 
     if (entry.isDirectory()) {
-      const nested = await collectJsFiles(fullPath);
+      const nested = await collectFiles(fullPath, extension);
       results.push(...nested);
-    } else if (entry.isFile() && entry.name.endsWith('.js')) {
-      results.push(fullPath);
-    }
-  }
-
-  return results;
-}
-
-/**
- * Recursively collects all `.d.ts` files under a directory.
- *
- * @param dir The directory to search.
- * @returns Absolute paths to every `.d.ts` file found.
- */
-async function collectDtsFiles(dir: string): Promise<string[]> {
-  const results: string[] = [];
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-
-    if (entry.isDirectory()) {
-      const nested = await collectDtsFiles(fullPath);
-      results.push(...nested);
-    } else if (entry.isFile() && entry.name.endsWith('.d.ts')) {
+    } else if (entry.isFile() && entry.name.endsWith(extension)) {
       results.push(fullPath);
     }
   }
@@ -145,7 +123,7 @@ async function collectDtsFiles(dir: string): Promise<string[]> {
 
 // Check all dist/browser/**/*.js for browser-global and bare-specifier violations.
 // This covers both main bundles and shared chunks emitted by the bundler.
-const browserJsFiles = await collectJsFiles(browserDir);
+const browserJsFiles = await collectFiles(browserDir, '.js');
 if (browserJsFiles.length === 0) {
   failures.push(`No .js files found under dist/browser/ — build may have failed.`);
 }
@@ -162,7 +140,7 @@ for (const jsFile of browserJsFiles) {
 assertEmptyRuntimeDependencies();
 
 // Check all dist/**/*.d.ts for bare-specifier violations.
-const dtsFiles = await collectDtsFiles(distDir);
+const dtsFiles = await collectFiles(distDir, '.d.ts');
 for (const dtsFile of dtsFiles) {
   const relLabel = path.relative(root, dtsFile);
   const source = await fs.readFile(dtsFile, 'utf8');

--- a/src/sequences/index.ts
+++ b/src/sequences/index.ts
@@ -5,9 +5,13 @@
  * root barrel at `octavian`). The root `src/index.ts` MUST NOT re-export
  * from this module.
  *
- * Convention: Each subpath lives in `src/<name>/index.ts`. The matching entry
- * is added to `entry` in `tsdown.config.ts` and to the `"exports"` map in
- * `package.json` under `"./<name>"`.
+ * Convention: Each subpath lives in `src/<name>/index.ts`. To add one:
+ *   1. Add `src/<name>/index.ts` to `entry` in `tsdown.config.ts`.
+ *   2. Add a matching `"./<name>"` block to the `"exports"` map in `package.json`
+ *      (types/browser/import/default, with `types` first).
+ *   3. Import the subpath in `scripts/smoke-consumer-check.mjs` and add an
+ *      assertion in `scripts/smoke-checks.mjs` so the tarball smoke test
+ *      exercises the new exports-map entry at runtime.
  *
  * Import path: `octavian/sequences`
  */

--- a/src/sequences/index.ts
+++ b/src/sequences/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Timed music-event and sequence primitives.
+ *
+ * Import as `octavian/sequences` (this is a subpath export, not part of the
+ * root barrel at `octavian`). The root `src/index.ts` MUST NOT re-export
+ * from this module.
+ *
+ * Convention: Each subpath lives in `src/<name>/index.ts`. The matching entry
+ * is added to `entry` in `tsdown.config.ts` and to the `"exports"` map in
+ * `package.json` under `"./<name>"`.
+ *
+ * Import path: `octavian/sequences`
+ */
+
+export { musicalTime, Sequence } from './sequence.js';
+
+export type {
+  MusicalTime,
+  MusicalDuration,
+  MusicEvent,
+  NoteEvent,
+  ChordEvent,
+  RestEvent,
+  TimedMusicEvent,
+  TimedNoteEvent,
+  TimedChordEvent,
+  TimedRestEvent,
+  SequenceOptions,
+  SerializedNoteEvent,
+  SerializedChordEvent,
+  SerializedRestEvent,
+  SerializedMusicEvent,
+  SerializedSequence,
+} from './types.js';

--- a/src/sequences/sequence.test.ts
+++ b/src/sequences/sequence.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect } from 'bun:test';
+import { Sequence, musicalTime } from './sequence.js';
+import { Note } from '../note.js';
+import { Chord } from '../chord.js';
+import type { MusicEvent, NoteEvent, ChordEvent, RestEvent } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const q: typeof musicalTime = musicalTime; // quarter = 1/4
+const QUARTER = q(1, 4);
+const HALF = q(1, 2);
+const WHOLE = q(1, 1);
+const EIGHTH = q(1, 8);
+
+function noteEvent(
+  noteName: string,
+  start: ReturnType<typeof q>,
+  duration: ReturnType<typeof q>,
+  velocity?: number,
+): NoteEvent {
+  const base: NoteEvent = {
+    type: 'note',
+    note: Note.create(noteName),
+    start,
+    duration,
+  };
+
+  if (velocity !== undefined) {
+    return { ...base, velocity };
+  }
+
+  return base;
+}
+
+function chordEvent(
+  root: string,
+  suffix: string,
+  start: ReturnType<typeof q>,
+  duration: ReturnType<typeof q>,
+  velocity?: number,
+): ChordEvent {
+  const base: ChordEvent = {
+    type: 'chord',
+    chord: Chord.create(Note.create(root), suffix),
+    start,
+    duration,
+  };
+
+  if (velocity !== undefined) {
+    return { ...base, velocity };
+  }
+
+  return base;
+}
+
+function restEvent(start: ReturnType<typeof q>, duration: ReturnType<typeof q>): RestEvent {
+  return { type: 'rest', start, duration };
+}
+
+// ---------------------------------------------------------------------------
+// musicalTime helper
+// ---------------------------------------------------------------------------
+
+describe('musicalTime', () => {
+  it('creates a reduced rational', () => {
+    const t = musicalTime(2, 8);
+    expect(t).toEqual({ numerator: 1, denominator: 4 });
+  });
+
+  it('throws RangeError for zero denominator', () => {
+    expect(() => musicalTime(1, 0)).toThrow(RangeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sequence.create
+// ---------------------------------------------------------------------------
+
+describe('Sequence.create', () => {
+  it('creates an empty sequence', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    expect(seq.isEmpty()).toBe(true);
+    expect(seq.events).toHaveLength(0);
+  });
+
+  it('stores the tempo', () => {
+    const seq = Sequence.create([], { tempo: 96 });
+    expect(seq.tempo).toBe(96);
+  });
+
+  it('stores null meter when none given', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    expect(seq.meter).toBeNull();
+  });
+
+  it('sorts events by start ascending', () => {
+    const events: MusicEvent[] = [
+      noteEvent('E4', HALF, QUARTER),
+      noteEvent('C4', q(0, 1), QUARTER),
+    ];
+
+    const seq = Sequence.create(events, { tempo: 120 });
+    expect(seq.events[0]?.type).toBe('note');
+    expect((seq.events[0] as NoteEvent).note.note).toBe('C');
+    expect((seq.events[1] as NoteEvent).note.note).toBe('E');
+  });
+
+  it('preserves overlapping events (polyphony)', () => {
+    const events: MusicEvent[] = [
+      noteEvent('C4', q(0, 1), WHOLE),
+      noteEvent('E4', q(0, 1), WHOLE),
+      noteEvent('G4', q(0, 1), WHOLE),
+    ];
+
+    const seq = Sequence.create(events, { tempo: 120 });
+    expect(seq.events).toHaveLength(3);
+  });
+
+  it('throws RangeError for invalid tempo (zero)', () => {
+    expect(() => Sequence.create([], { tempo: 0 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for invalid tempo (negative)', () => {
+    expect(() => Sequence.create([], { tempo: -60 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for velocity out of range', () => {
+    const event = noteEvent('C4', q(0, 1), QUARTER, 200);
+    expect(() => Sequence.create([event], { tempo: 120 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for negative start time', () => {
+    const event: NoteEvent = {
+      type: 'note',
+      note: Note.create('C4'),
+      start: { numerator: -1, denominator: 4 },
+      duration: QUARTER,
+    };
+
+    expect(() => Sequence.create([event], { tempo: 120 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for zero duration', () => {
+    const event: NoteEvent = {
+      type: 'note',
+      note: Note.create('C4'),
+      start: q(0, 1),
+      duration: { numerator: 0, denominator: 1 },
+    };
+
+    expect(() => Sequence.create([event], { tempo: 120 })).toThrow(RangeError);
+  });
+
+  it('accepts rest events', () => {
+    const seq = Sequence.create([restEvent(q(0, 1), QUARTER)], { tempo: 120 });
+    expect(seq.events[0]?.type).toBe('rest');
+  });
+
+  it('accepts chord events', () => {
+    const seq = Sequence.create([chordEvent('C4', '', q(0, 1), WHOLE)], { tempo: 120 });
+    expect(seq.events[0]?.type).toBe('chord');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toAbsoluteSeconds — tempo conversion
+// ---------------------------------------------------------------------------
+
+describe('Sequence.toAbsoluteSeconds', () => {
+  it('quarter note at 120 BPM = 0.5s', () => {
+    const seq = Sequence.create([noteEvent('C4', QUARTER, QUARTER)], { tempo: 120 });
+    const [timed] = seq.toAbsoluteSeconds();
+
+    expect(timed?.startSeconds).toBeCloseTo(0.5);
+    expect(timed?.durationSeconds).toBeCloseTo(0.5);
+  });
+
+  it('whole note at 60 BPM = 4s duration', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), WHOLE)], { tempo: 60 });
+    const [timed] = seq.toAbsoluteSeconds();
+
+    expect(timed?.durationSeconds).toBeCloseTo(4);
+  });
+
+  it('eighth note at 120 BPM = 0.25s', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), EIGHTH)], { tempo: 120 });
+    const [timed] = seq.toAbsoluteSeconds();
+
+    expect(timed?.durationSeconds).toBeCloseTo(0.25);
+  });
+
+  it('start = 0 has startSeconds = 0', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const [timed] = seq.toAbsoluteSeconds();
+
+    expect(timed?.startSeconds).toBeCloseTo(0);
+  });
+
+  it('returns timed events with same type discriminants', () => {
+    const seq = Sequence.create(
+      [
+        noteEvent('C4', q(0, 1), QUARTER),
+        chordEvent('F4', '', QUARTER, HALF),
+        restEvent(q(3, 4), QUARTER),
+      ],
+      { tempo: 120 },
+    );
+    const timed = seq.toAbsoluteSeconds();
+
+    expect(timed[0]?.type).toBe('note');
+    expect(timed[1]?.type).toBe('chord');
+    expect(timed[2]?.type).toBe('rest');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// eventsInRange
+// ---------------------------------------------------------------------------
+
+describe('Sequence.eventsInRange', () => {
+  const events: MusicEvent[] = [
+    noteEvent('C4', q(0, 1), QUARTER),
+    noteEvent('D4', QUARTER, QUARTER),
+    noteEvent('E4', HALF, QUARTER),
+    noteEvent('F4', q(3, 4), QUARTER),
+  ];
+
+  const seq = Sequence.create(events, { tempo: 120 });
+
+  it('returns events within [0, 1/2)', () => {
+    const result = seq.eventsInRange(q(0, 1), HALF);
+    expect(result).toHaveLength(2);
+    expect((result[0] as NoteEvent).note.note).toBe('C');
+    expect((result[1] as NoteEvent).note.note).toBe('D');
+  });
+
+  it('is inclusive of startTime', () => {
+    const result = seq.eventsInRange(HALF, WHOLE);
+    expect(result).toHaveLength(2);
+    expect((result[0] as NoteEvent).note.note).toBe('E');
+  });
+
+  it('is exclusive of endTime', () => {
+    const result = seq.eventsInRange(q(0, 1), q(3, 4));
+    expect(result).toHaveLength(3);
+  });
+
+  it('returns empty array when no events in range', () => {
+    const result = seq.eventsInRange(q(2, 1), q(3, 1));
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transpose
+// ---------------------------------------------------------------------------
+
+describe('Sequence.transpose', () => {
+  it('transposes note events', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const transposed = seq.transpose('majorSecond');
+
+    expect((transposed.events[0] as NoteEvent).note.note).toBe('D');
+  });
+
+  it('transposes chord events', () => {
+    const seq = Sequence.create([chordEvent('C4', '', q(0, 1), WHOLE)], { tempo: 120 });
+    const transposed = seq.transpose('perfectFifth');
+
+    expect((transposed.events[0] as ChordEvent).chord.root.note).toBe('G');
+  });
+
+  it('leaves rest events unchanged', () => {
+    const seq = Sequence.create([restEvent(q(0, 1), QUARTER)], { tempo: 120 });
+    const transposed = seq.transpose('majorSecond');
+
+    expect(transposed.events[0]?.type).toBe('rest');
+    expect(transposed.events[0]).toEqual(seq.events[0]);
+  });
+
+  it('preserves tempo and meter after transpose', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 96 });
+    const transposed = seq.transpose('minorThird');
+
+    expect(transposed.tempo).toBe(96);
+    expect(transposed.meter).toBeNull();
+  });
+
+  it('preserves velocity after transpose', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER, 80)], { tempo: 120 });
+    const transposed = seq.transpose('majorSecond');
+
+    expect((transposed.events[0] as NoteEvent).velocity).toBe(80);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// totalDuration
+// ---------------------------------------------------------------------------
+
+describe('Sequence.totalDuration', () => {
+  it('returns 0 for empty sequence', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    expect(seq.totalDuration()).toEqual({ numerator: 0, denominator: 1 });
+  });
+
+  it('returns start + duration of latest-ending event', () => {
+    const seq = Sequence.create(
+      [
+        noteEvent('C4', q(0, 1), QUARTER), // ends at 1/4
+        noteEvent('D4', QUARTER, HALF), // ends at 3/4
+        noteEvent('E4', HALF, QUARTER), // ends at 3/4
+      ],
+      { tempo: 120 },
+    );
+    // Latest end is 3/4
+    expect(seq.totalDuration()).toEqual({ numerator: 3, denominator: 4 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Serialization round-trip
+// ---------------------------------------------------------------------------
+
+describe('Sequence.toJSON / fromJSON', () => {
+  it('round-trips a note event sequence', () => {
+    const original = Sequence.create(
+      [
+        noteEvent('C4', q(0, 1), QUARTER),
+        noteEvent('E4', QUARTER, QUARTER, 64),
+        restEvent(HALF, QUARTER),
+      ],
+      { tempo: 120 },
+    );
+
+    const json = original.toJSON();
+    const restored = Sequence.fromJSON(json);
+
+    expect(restored.equals(original)).toBe(true);
+  });
+
+  it('round-trips a chord event without velocity', () => {
+    const original = Sequence.create([chordEvent('C4', 'maj7', q(0, 1), WHOLE)], { tempo: 80 });
+
+    const json = original.toJSON();
+    const restored = Sequence.fromJSON(json);
+
+    expect(restored.equals(original)).toBe(true);
+  });
+
+  it('round-trips a chord event with velocity', () => {
+    const original = Sequence.create([chordEvent('G4', '', q(0, 1), HALF, 90)], { tempo: 120 });
+
+    const json = original.toJSON();
+    const restored = Sequence.fromJSON(json);
+
+    expect(restored.equals(original)).toBe(true);
+    expect((restored.events[0] as ChordEvent).velocity).toBe(90);
+  });
+
+  it('produces deterministic JSON', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const json1 = JSON.stringify(seq.toJSON());
+    const json2 = JSON.stringify(seq.toJSON());
+
+    expect(json1).toBe(json2);
+  });
+
+  it('throws TypeError for invalid tempo in fromJSON', () => {
+    expect(() => Sequence.fromJSON({ tempo: 0, meter: null, events: [] })).toThrow(TypeError);
+  });
+
+  it('round-trips with a rest event', () => {
+    const original = Sequence.create([restEvent(q(0, 1), QUARTER)], { tempo: 120 });
+    const restored = Sequence.fromJSON(original.toJSON());
+
+    expect(restored.equals(original)).toBe(true);
+  });
+
+  it('serializes meter as null when absent', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    expect(seq.toJSON().meter).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// equals
+// ---------------------------------------------------------------------------
+
+describe('Sequence.equals', () => {
+  it('considers two empty sequences with same tempo equal', () => {
+    const a = Sequence.create([], { tempo: 120 });
+    const b = Sequence.create([], { tempo: 120 });
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it('considers two sequences unequal when tempos differ', () => {
+    const a = Sequence.create([], { tempo: 120 });
+    const b = Sequence.create([], { tempo: 96 });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers two sequences unequal when event counts differ', () => {
+    const a = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const b = Sequence.create([], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Symbol.toStringTag
+// ---------------------------------------------------------------------------
+
+describe('Sequence[Symbol.toStringTag]', () => {
+  it('returns a descriptive tag', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    expect(seq[Symbol.toStringTag]).toBe('Sequence(1 event(s), 120 BPM)');
+  });
+});

--- a/src/sequences/sequence.test.ts
+++ b/src/sequences/sequence.test.ts
@@ -226,6 +226,16 @@ describe('Sequence.create', () => {
     expect(() => Sequence.create([event], { tempo: 120 })).toThrow(RangeError);
   });
 
+  it('throws TypeError for an unknown event discriminant', () => {
+    const bogus = {
+      type: 'glissando',
+      start: q(0, 1),
+      duration: QUARTER,
+    } as unknown as MusicEvent;
+
+    expect(() => Sequence.create([bogus], { tempo: 120 })).toThrow(TypeError);
+  });
+
   it('accepts rest events', () => {
     const seq = Sequence.create([restEvent(q(0, 1), QUARTER)], { tempo: 120 });
     expect(seq.events[0]?.type).toBe('rest');

--- a/src/sequences/sequence.test.ts
+++ b/src/sequences/sequence.test.ts
@@ -3,7 +3,6 @@ import { Sequence, musicalTime } from './sequence.js';
 import { Sequence as SequenceFromBarrel, musicalTime as musicalTimeFromBarrel } from './index.js';
 import { Note } from '../note.js';
 import { Chord } from '../chord.js';
-import { Meter } from '../meter.js';
 import type { MusicEvent, NoteEvent, ChordEvent, RestEvent } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -130,6 +129,78 @@ describe('Sequence.create', () => {
 
   it('throws RangeError for velocity out of range', () => {
     const event = noteEvent('C4', q(0, 1), QUARTER, 200);
+    expect(() => Sequence.create([event], { tempo: 120 })).toThrow(RangeError);
+  });
+
+  it('accepts velocity 0 (lower boundary)', () => {
+    const event = noteEvent('C4', q(0, 1), QUARTER, 0);
+    expect(() => Sequence.create([event], { tempo: 120 })).not.toThrow();
+  });
+
+  it('accepts velocity 127 (upper boundary)', () => {
+    const event = noteEvent('C4', q(0, 1), QUARTER, 127);
+    expect(() => Sequence.create([event], { tempo: 120 })).not.toThrow();
+  });
+
+  it('throws RangeError for velocity below 0', () => {
+    const event = noteEvent('C4', q(0, 1), QUARTER, -1);
+    expect(() => Sequence.create([event], { tempo: 120 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-integer velocity', () => {
+    const event = noteEvent('C4', q(0, 1), QUARTER, 63.5);
+    expect(() => Sequence.create([event], { tempo: 120 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite tempo (NaN)', () => {
+    expect(() => Sequence.create([], { tempo: NaN })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite tempo (Infinity)', () => {
+    expect(() => Sequence.create([], { tempo: Infinity })).toThrow(RangeError);
+  });
+
+  it('throws TypeError for non-integer start numerator', () => {
+    const event: NoteEvent = {
+      type: 'note',
+      note: Note.create('C4'),
+      start: { numerator: 1.5, denominator: 4 },
+      duration: QUARTER,
+    };
+
+    expect(() => Sequence.create([event], { tempo: 120 })).toThrow(TypeError);
+  });
+
+  it('throws RangeError for non-positive start denominator', () => {
+    const event: NoteEvent = {
+      type: 'note',
+      note: Note.create('C4'),
+      start: { numerator: 1, denominator: -4 },
+      duration: QUARTER,
+    };
+
+    expect(() => Sequence.create([event], { tempo: 120 })).toThrow(RangeError);
+  });
+
+  it('throws TypeError for non-integer duration denominator', () => {
+    const event: NoteEvent = {
+      type: 'note',
+      note: Note.create('C4'),
+      start: q(0, 1),
+      duration: { numerator: 1, denominator: 2.5 },
+    };
+
+    expect(() => Sequence.create([event], { tempo: 120 })).toThrow(TypeError);
+  });
+
+  it('throws RangeError for non-positive duration denominator', () => {
+    const event: NoteEvent = {
+      type: 'note',
+      note: Note.create('C4'),
+      start: q(0, 1),
+      duration: { numerator: 1, denominator: 0 },
+    };
+
     expect(() => Sequence.create([event], { tempo: 120 })).toThrow(RangeError);
   });
 
@@ -326,201 +397,12 @@ describe('Sequence.totalDuration', () => {
 // Serialization round-trip
 // ---------------------------------------------------------------------------
 
-describe('Sequence.toJSON / fromJSON', () => {
-  it('round-trips a note event sequence', () => {
-    const original = Sequence.create(
-      [
-        noteEvent('C4', q(0, 1), QUARTER),
-        noteEvent('E4', QUARTER, QUARTER, 64),
-        restEvent(HALF, QUARTER),
-      ],
-      { tempo: 120 },
-    );
-
-    const json = original.toJSON();
-    const restored = Sequence.fromJSON(json);
-
-    expect(restored.equals(original)).toBe(true);
-  });
-
-  it('round-trips a chord event without velocity', () => {
-    const original = Sequence.create([chordEvent('C4', 'maj7', q(0, 1), WHOLE)], { tempo: 80 });
-
-    const json = original.toJSON();
-    const restored = Sequence.fromJSON(json);
-
-    expect(restored.equals(original)).toBe(true);
-  });
-
-  it('round-trips a chord event with velocity', () => {
-    const original = Sequence.create([chordEvent('G4', '', q(0, 1), HALF, 90)], { tempo: 120 });
-
-    const json = original.toJSON();
-    const restored = Sequence.fromJSON(json);
-
-    expect(restored.equals(original)).toBe(true);
-    expect((restored.events[0] as ChordEvent).velocity).toBe(90);
-  });
-
-  it('produces deterministic JSON', () => {
-    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
-    const json1 = JSON.stringify(seq.toJSON());
-    const json2 = JSON.stringify(seq.toJSON());
-
-    expect(json1).toBe(json2);
-  });
-
-  it('throws TypeError for invalid tempo in fromJSON', () => {
-    expect(() => Sequence.fromJSON({ tempo: 0, meter: null, events: [] })).toThrow(TypeError);
-  });
-
-  it('round-trips with a rest event', () => {
-    const original = Sequence.create([restEvent(q(0, 1), QUARTER)], { tempo: 120 });
-    const restored = Sequence.fromJSON(original.toJSON());
-
-    expect(restored.equals(original)).toBe(true);
-  });
-
-  it('serializes meter as null when absent', () => {
-    const seq = Sequence.create([], { tempo: 120 });
-    expect(seq.toJSON().meter).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// equals
-// ---------------------------------------------------------------------------
-
-describe('Sequence.equals', () => {
-  it('considers two empty sequences with same tempo equal', () => {
-    const a = Sequence.create([], { tempo: 120 });
-    const b = Sequence.create([], { tempo: 120 });
-    expect(a.equals(b)).toBe(true);
-  });
-
-  it('considers two sequences unequal when tempos differ', () => {
-    const a = Sequence.create([], { tempo: 120 });
-    const b = Sequence.create([], { tempo: 96 });
-    expect(a.equals(b)).toBe(false);
-  });
-
-  it('considers two sequences unequal when event counts differ', () => {
-    const a = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
-    const b = Sequence.create([], { tempo: 120 });
-    expect(a.equals(b)).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Symbol.toStringTag
-// ---------------------------------------------------------------------------
-
-describe('Sequence[Symbol.toStringTag]', () => {
-  it('returns a descriptive tag', () => {
-    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
-    expect(seq[Symbol.toStringTag]).toBe('Sequence(1 event(s), 120 BPM)');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Meter option
-// ---------------------------------------------------------------------------
-
-describe('Sequence with meter', () => {
-  it('stores the meter when provided', () => {
-    const meter = Meter.create('4/4');
-    const seq = Sequence.create([], { tempo: 120, meter });
-    expect(seq.meter).not.toBeNull();
-    expect(seq.meter?.numerator).toBe(4);
-    expect(seq.meter?.denominator).toBe(4);
-  });
-
-  it('uses meter.beatUnit for toAbsoluteSeconds in 4/4', () => {
-    // 4/4: beatUnit = 1/4; quarter note at 120 BPM = 0.5s (same as no-meter)
-    const meter = Meter.create('4/4');
-    const seq = Sequence.create([noteEvent('C4', QUARTER, QUARTER)], { tempo: 120, meter });
-    const [timed] = seq.toAbsoluteSeconds();
-    expect(timed?.startSeconds).toBeCloseTo(0.5);
-    expect(timed?.durationSeconds).toBeCloseTo(0.5);
-  });
-
-  it('uses meter.beatUnit for toAbsoluteSeconds in 6/8 (compound)', () => {
-    // 6/8: beatUnit = 3/8; dotted quarter = 3/8 = one beat at 120 BPM → 0.5s
-    const meter = Meter.create('6/8');
-    const dottedQuarter = q(3, 8);
-    const seq = Sequence.create([noteEvent('C4', dottedQuarter, dottedQuarter)], {
-      tempo: 120,
-      meter,
-    });
-    const [timed] = seq.toAbsoluteSeconds();
-    // start = 3/8 beat; beatUnit = 3/8 → 1 beat → 0.5s
-    expect(timed?.startSeconds).toBeCloseTo(0.5);
-    expect(timed?.durationSeconds).toBeCloseTo(0.5);
-  });
-
-  it('round-trips a sequence with meter via toJSON/fromJSON', () => {
-    const meter = Meter.create('6/8');
-    const original = Sequence.create([noteEvent('C4', q(0, 1), q(3, 8))], { tempo: 120, meter });
-
-    const json = original.toJSON();
-    const restored = Sequence.fromJSON(json);
-
-    // meter must be a real Meter instance with beatUnit
-    expect(restored.meter).not.toBeNull();
-    expect(restored.meter).toBeInstanceOf(Meter);
-    expect(restored.meter?.numerator).toBe(6);
-    expect(restored.meter?.denominator).toBe(8);
-    expect(restored.equals(original)).toBe(true);
-  });
-
-  it('toAbsoluteSeconds works correctly after fromJSON with meter', () => {
-    const meter = Meter.create('6/8');
-    const dottedQuarter = q(3, 8);
-    const original = Sequence.create([noteEvent('C4', dottedQuarter, dottedQuarter)], {
-      tempo: 120,
-      meter,
-    });
-
-    const restored = Sequence.fromJSON(original.toJSON());
-    const [timed] = restored.toAbsoluteSeconds();
-
-    // Should use meter.beatUnit = 3/8; dotted quarter at 120 BPM → 0.5s
-    expect(timed?.startSeconds).toBeCloseTo(0.5);
-    expect(timed?.durationSeconds).toBeCloseTo(0.5);
-  });
-
-  it('preserves meter after transpose', () => {
-    const meter = Meter.create('3/4');
-    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120, meter });
-    const transposed = seq.transpose('majorSecond');
-
-    expect(transposed.meter).not.toBeNull();
-    expect(transposed.meter?.numerator).toBe(3);
-    expect(transposed.meter?.denominator).toBe(4);
-  });
-
-  it('considers two sequences with same meter equal', () => {
-    const meter = Meter.create('3/4');
-    const a = Sequence.create([], { tempo: 120, meter });
-    const b = Sequence.create([], { tempo: 120, meter: Meter.create('3/4') });
-    expect(a.equals(b)).toBe(true);
-  });
-
-  it('considers two sequences unequal when meters differ', () => {
-    const a = Sequence.create([], { tempo: 120, meter: Meter.create('4/4') });
-    const b = Sequence.create([], { tempo: 120, meter: Meter.create('3/4') });
-    expect(a.equals(b)).toBe(false);
-  });
-
-  it('considers sequence with meter unequal to one without', () => {
-    const a = Sequence.create([], { tempo: 120, meter: Meter.create('4/4') });
-    const b = Sequence.create([], { tempo: 120 });
-    expect(a.equals(b)).toBe(false);
-  });
-});
-
 // ---------------------------------------------------------------------------
 // Subpath barrel (index.js)
+//
+// Serialization, equality, Symbol.toStringTag, and meter coverage live in the
+// companion file serialization.test.ts (kept separate to stay under the
+// max-lines lint cap).
 // ---------------------------------------------------------------------------
 
 describe('octavian/sequences barrel exports', () => {

--- a/src/sequences/sequence.test.ts
+++ b/src/sequences/sequence.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'bun:test';
 import { Sequence, musicalTime } from './sequence.js';
+import { Sequence as SequenceFromBarrel, musicalTime as musicalTimeFromBarrel } from './index.js';
 import { Note } from '../note.js';
 import { Chord } from '../chord.js';
+import { Meter } from '../meter.js';
 import type { MusicEvent, NoteEvent, ChordEvent, RestEvent } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -417,5 +419,121 @@ describe('Sequence[Symbol.toStringTag]', () => {
   it('returns a descriptive tag', () => {
     const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
     expect(seq[Symbol.toStringTag]).toBe('Sequence(1 event(s), 120 BPM)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Meter option
+// ---------------------------------------------------------------------------
+
+describe('Sequence with meter', () => {
+  it('stores the meter when provided', () => {
+    const meter = Meter.create('4/4');
+    const seq = Sequence.create([], { tempo: 120, meter });
+    expect(seq.meter).not.toBeNull();
+    expect(seq.meter?.numerator).toBe(4);
+    expect(seq.meter?.denominator).toBe(4);
+  });
+
+  it('uses meter.beatUnit for toAbsoluteSeconds in 4/4', () => {
+    // 4/4: beatUnit = 1/4; quarter note at 120 BPM = 0.5s (same as no-meter)
+    const meter = Meter.create('4/4');
+    const seq = Sequence.create([noteEvent('C4', QUARTER, QUARTER)], { tempo: 120, meter });
+    const [timed] = seq.toAbsoluteSeconds();
+    expect(timed?.startSeconds).toBeCloseTo(0.5);
+    expect(timed?.durationSeconds).toBeCloseTo(0.5);
+  });
+
+  it('uses meter.beatUnit for toAbsoluteSeconds in 6/8 (compound)', () => {
+    // 6/8: beatUnit = 3/8; dotted quarter = 3/8 = one beat at 120 BPM → 0.5s
+    const meter = Meter.create('6/8');
+    const dottedQuarter = q(3, 8);
+    const seq = Sequence.create([noteEvent('C4', dottedQuarter, dottedQuarter)], {
+      tempo: 120,
+      meter,
+    });
+    const [timed] = seq.toAbsoluteSeconds();
+    // start = 3/8 beat; beatUnit = 3/8 → 1 beat → 0.5s
+    expect(timed?.startSeconds).toBeCloseTo(0.5);
+    expect(timed?.durationSeconds).toBeCloseTo(0.5);
+  });
+
+  it('round-trips a sequence with meter via toJSON/fromJSON', () => {
+    const meter = Meter.create('6/8');
+    const original = Sequence.create([noteEvent('C4', q(0, 1), q(3, 8))], { tempo: 120, meter });
+
+    const json = original.toJSON();
+    const restored = Sequence.fromJSON(json);
+
+    // meter must be a real Meter instance with beatUnit
+    expect(restored.meter).not.toBeNull();
+    expect(restored.meter).toBeInstanceOf(Meter);
+    expect(restored.meter?.numerator).toBe(6);
+    expect(restored.meter?.denominator).toBe(8);
+    expect(restored.equals(original)).toBe(true);
+  });
+
+  it('toAbsoluteSeconds works correctly after fromJSON with meter', () => {
+    const meter = Meter.create('6/8');
+    const dottedQuarter = q(3, 8);
+    const original = Sequence.create([noteEvent('C4', dottedQuarter, dottedQuarter)], {
+      tempo: 120,
+      meter,
+    });
+
+    const restored = Sequence.fromJSON(original.toJSON());
+    const [timed] = restored.toAbsoluteSeconds();
+
+    // Should use meter.beatUnit = 3/8; dotted quarter at 120 BPM → 0.5s
+    expect(timed?.startSeconds).toBeCloseTo(0.5);
+    expect(timed?.durationSeconds).toBeCloseTo(0.5);
+  });
+
+  it('preserves meter after transpose', () => {
+    const meter = Meter.create('3/4');
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120, meter });
+    const transposed = seq.transpose('majorSecond');
+
+    expect(transposed.meter).not.toBeNull();
+    expect(transposed.meter?.numerator).toBe(3);
+    expect(transposed.meter?.denominator).toBe(4);
+  });
+
+  it('considers two sequences with same meter equal', () => {
+    const meter = Meter.create('3/4');
+    const a = Sequence.create([], { tempo: 120, meter });
+    const b = Sequence.create([], { tempo: 120, meter: Meter.create('3/4') });
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it('considers two sequences unequal when meters differ', () => {
+    const a = Sequence.create([], { tempo: 120, meter: Meter.create('4/4') });
+    const b = Sequence.create([], { tempo: 120, meter: Meter.create('3/4') });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers sequence with meter unequal to one without', () => {
+    const a = Sequence.create([], { tempo: 120, meter: Meter.create('4/4') });
+    const b = Sequence.create([], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subpath barrel (index.js)
+// ---------------------------------------------------------------------------
+
+describe('octavian/sequences barrel exports', () => {
+  it('exports Sequence from barrel', () => {
+    expect(SequenceFromBarrel).toBe(Sequence);
+  });
+
+  it('exports musicalTime from barrel', () => {
+    expect(musicalTimeFromBarrel).toBe(musicalTime);
+  });
+
+  it('barrel Sequence.create works end-to-end', () => {
+    const seq = SequenceFromBarrel.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    expect(seq.events).toHaveLength(1);
   });
 });

--- a/src/sequences/sequence.ts
+++ b/src/sequences/sequence.ts
@@ -1,0 +1,431 @@
+/**
+ * The {@link Sequence} value object and related validation helpers.
+ *
+ * Seconds conversion
+ * ------------------
+ * `toAbsoluteSeconds` converts musical time to real time using:
+ *   `seconds = (timeFraction / beatUnit) * (60 / tempo)`
+ * where `beatUnit` is the whole-note fraction for one beat.
+ * - Without a meter: `beatUnit = 1/4` (quarter note = one beat, standard 4/4 feel).
+ * - With a meter: `beatUnit = meter.beatUnit` (e.g. 6/8 → `3/8`, compound meter).
+ * Check: quarter note at 120 BPM → `(1/4 ÷ 1/4) × (60/120) = 0.5 s`. Correct.
+ */
+
+import type { Interval } from '../intervals.js';
+import {
+  type Rational,
+  createRational,
+  addRationals,
+  compareRationals,
+  rationalsEqual,
+  rationalToNumber,
+} from '../rational.js';
+import type { Meter } from '../meter.js';
+import { serializeEvent, deserializeEvent } from './serialization.js';
+import type {
+  MusicEvent,
+  NoteEvent,
+  ChordEvent,
+  MusicalTime,
+  MusicalDuration,
+  SequenceOptions,
+  SerializedSequence,
+  TimedMusicEvent,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convenience constructor for a {@link MusicalTime} or {@link MusicalDuration}
+ * from a `[numerator, denominator]` pair.
+ *
+ * @param numerator The numerator (must be a non-negative integer).
+ * @param denominator The denominator (must be a positive integer).
+ * @returns The reduced rational fraction.
+ */
+export function musicalTime(numerator: number, denominator: number): MusicalTime {
+  return createRational(numerator, denominator);
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function validateTempo(tempo: number): void {
+  if (!Number.isFinite(tempo) || tempo <= 0) {
+    throw new RangeError(`Tempo must be a finite positive number, received ${tempo}.`);
+  }
+}
+
+function validateVelocity(velocity: number | undefined): void {
+  if (velocity === undefined) return;
+
+  if (!Number.isInteger(velocity) || velocity < 0 || velocity > 127) {
+    throw new RangeError(`Velocity must be an integer in 0..127, received ${velocity}.`);
+  }
+}
+
+function validateMusicalTime(value: Rational, label: string): void {
+  if (!Number.isInteger(value.numerator) || !Number.isInteger(value.denominator)) {
+    throw new TypeError(`${label} must be a rational with integer numerator/denominator.`);
+  }
+
+  if (value.denominator <= 0) {
+    throw new RangeError(`${label} denominator must be positive, received ${value.denominator}.`);
+  }
+
+  if (value.numerator < 0) {
+    throw new RangeError(
+      `${label} must be non-negative, received ${value.numerator}/${value.denominator}.`,
+    );
+  }
+}
+
+function validateMusicalDuration(value: Rational): void {
+  if (!Number.isInteger(value.numerator) || !Number.isInteger(value.denominator)) {
+    throw new TypeError('Duration must be a rational with integer numerator/denominator.');
+  }
+
+  if (value.denominator <= 0) {
+    throw new RangeError(`Duration denominator must be positive, received ${value.denominator}.`);
+  }
+
+  if (value.numerator <= 0) {
+    throw new RangeError(
+      `Duration must be positive, received ${value.numerator}/${value.denominator}.`,
+    );
+  }
+}
+
+function validateEvent(event: MusicEvent): void {
+  validateMusicalTime(event.start, 'start');
+  validateMusicalDuration(event.duration);
+
+  if (event.type !== 'rest') {
+    validateVelocity(event.velocity);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transpose helpers
+// ---------------------------------------------------------------------------
+
+function transposeNoteEvent(event: NoteEvent, interval: Interval): NoteEvent {
+  const base: NoteEvent = {
+    type: 'note',
+    note: event.note.transpose(interval),
+    start: event.start,
+    duration: event.duration,
+  };
+
+  if (event.velocity !== undefined) {
+    return { ...base, velocity: event.velocity };
+  }
+
+  return base;
+}
+
+function transposeChordEvent(event: ChordEvent, interval: Interval): ChordEvent {
+  const base: ChordEvent = {
+    type: 'chord',
+    chord: event.chord.transpose(interval),
+    start: event.start,
+    duration: event.duration,
+  };
+
+  if (event.velocity !== undefined) {
+    return { ...base, velocity: event.velocity };
+  }
+
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// Equality helpers
+// ---------------------------------------------------------------------------
+
+function metersMatch(a: Meter | null, b: Meter | null): boolean {
+  if ((a === null) !== (b === null)) return false;
+
+  if (a !== null && b !== null) {
+    return a.numerator === b.numerator && a.denominator === b.denominator;
+  }
+
+  return true;
+}
+
+function noteEventsMatch(a: NoteEvent, b: NoteEvent): boolean {
+  return (
+    a.note.note === b.note.note && a.note.octave === b.note.octave && a.velocity === b.velocity
+  );
+}
+
+function chordEventsMatch(a: ChordEvent, b: ChordEvent): boolean {
+  return (
+    a.chord.root.note === b.chord.root.note &&
+    a.chord.root.octave === b.chord.root.octave &&
+    a.chord.suffix === b.chord.suffix &&
+    a.velocity === b.velocity
+  );
+}
+
+function eventsMatch(a: MusicEvent, b: MusicEvent): boolean {
+  if (a.type !== b.type) return false;
+  if (!rationalsEqual(a.start, b.start)) return false;
+  if (!rationalsEqual(a.duration, b.duration)) return false;
+
+  if (a.type === 'note' && b.type === 'note') return noteEventsMatch(a, b);
+  if (a.type === 'chord' && b.type === 'chord') return chordEventsMatch(a, b);
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Module-scoped factory — populated by Sequence static {}
+// ---------------------------------------------------------------------------
+
+let createSequence: (events: readonly MusicEvent[], tempo: number, meter: Meter | null) => Sequence;
+
+// ---------------------------------------------------------------------------
+// Sequence value object
+// ---------------------------------------------------------------------------
+
+/**
+ * An immutable, ordered collection of timed music events at a fixed tempo.
+ *
+ * Events are stored sorted by `start` ascending. Overlapping events are
+ * preserved as-is (polyphony).
+ */
+export class Sequence {
+  readonly #events: readonly MusicEvent[];
+  readonly #tempo: number;
+  readonly #meter: Meter | null;
+
+  /** @internal Use {@link Sequence.create} or {@link Sequence.fromJSON} instead. */
+  protected constructor(events: readonly MusicEvent[], tempo: number, meter: Meter | null) {
+    this.#events = events;
+    this.#tempo = tempo;
+    this.#meter = meter;
+  }
+
+  static {
+    createSequence = (
+      events: readonly MusicEvent[],
+      tempo: number,
+      meter: Meter | null,
+    ): Sequence => new Sequence(events, tempo, meter);
+  }
+
+  /**
+   * Creates a {@link Sequence} from an array of events and tempo options.
+   *
+   * Events are sorted by `start` ascending on creation; overlapping events are
+   * preserved (polyphony). Rests, notes, and chords may be interleaved freely.
+   *
+   * @param events The events to include.
+   * @param options Tempo and optional meter.
+   * @returns The created sequence.
+   * @throws {RangeError} When `tempo` is not a finite positive number.
+   * @throws {RangeError} When an event has a negative start or non-positive duration.
+   * @throws {RangeError} When a velocity is outside 0..127.
+   */
+  public static create(events: readonly MusicEvent[], options: SequenceOptions): Sequence {
+    validateTempo(options.tempo);
+
+    for (const event of events) {
+      validateEvent(event);
+    }
+
+    const sorted = [...events].toSorted((a, b) => compareRationals(a.start, b.start));
+
+    return createSequence(sorted, options.tempo, options.meter ?? null);
+  }
+
+  /**
+   * Recreates a {@link Sequence} from serialized data produced by {@link Sequence.toJSON}.
+   *
+   * @param serialized The serialized sequence.
+   * @returns The recreated sequence.
+   * @throws {TypeError} When the serialized tempo is invalid.
+   */
+  public static fromJSON(serialized: SerializedSequence): Sequence {
+    if (!Number.isFinite(serialized.tempo) || serialized.tempo <= 0) {
+      throw new TypeError(`Serialized tempo must be a finite positive number.`);
+    }
+
+    const events = serialized.events.map(deserializeEvent);
+    const sorted = [...events].toSorted((a, b) => compareRationals(a.start, b.start));
+
+    // The meter shape { numerator, denominator } is compatible with Meter's
+    // public interface. Callers needing full Meter behaviour can reconstruct
+    // via Meter.fromJSON(sequence.meter).
+    const meter = serialized.meter as Meter | null;
+
+    return createSequence(sorted, serialized.tempo, meter);
+  }
+
+  /**
+   * The events in this sequence, sorted by start ascending.
+   */
+  public get events(): readonly MusicEvent[] {
+    return this.#events;
+  }
+
+  /**
+   * The tempo in BPM.
+   */
+  public get tempo(): number {
+    return this.#tempo;
+  }
+
+  /**
+   * The meter, or `null` when none was specified.
+   */
+  public get meter(): Meter | null {
+    return this.#meter;
+  }
+
+  /**
+   * Returns a new sequence with all note and chord events transposed by
+   * the given interval. Rest events are unchanged.
+   *
+   * @param interval The interval to transpose by.
+   * @returns The transposed sequence.
+   */
+  public transpose(interval: Interval): Sequence {
+    const transposed = this.#events.map((event): MusicEvent => {
+      if (event.type === 'note') return transposeNoteEvent(event, interval);
+      if (event.type === 'chord') return transposeChordEvent(event, interval);
+
+      return event;
+    });
+
+    return createSequence(transposed, this.#tempo, this.#meter);
+  }
+
+  /**
+   * Returns events with absolute real-time positions computed from the sequence tempo and meter.
+   *
+   * Conversion formula:
+   *   `seconds = (timeFraction / beatUnit) * (60 / tempo)`
+   *
+   * where `beatUnit` is the whole-note fraction for one beat:
+   * - No meter: `beatUnit = 1/4` (quarter note = one beat; standard 4/4 feel).
+   * - With meter: `beatUnit = meter.beatUnit` (e.g. 6/8 → `3/8`, compound meter).
+   *
+   * @returns Events with `startSeconds` and `durationSeconds` added.
+   */
+  public toAbsoluteSeconds(): readonly TimedMusicEvent[] {
+    const beatUnit: Rational =
+      this.#meter !== null ? this.#meter.beatUnit : { numerator: 1, denominator: 4 };
+
+    const secondsPerBeat = 60 / this.#tempo;
+
+    const fractionToSeconds = (fraction: Rational): number => {
+      const beats = rationalToNumber(fraction) / rationalToNumber(beatUnit);
+      return beats * secondsPerBeat;
+    };
+
+    return this.#events.map((event) => ({
+      ...event,
+      startSeconds: fractionToSeconds(event.start),
+      durationSeconds: fractionToSeconds(event.duration),
+    })) as readonly TimedMusicEvent[];
+  }
+
+  /**
+   * Returns all events whose `start` falls within `[startTime, endTime)`.
+   *
+   * The window is half-open: inclusive of `startTime`, exclusive of `endTime`.
+   *
+   * @param startTime The inclusive lower bound.
+   * @param endTime The exclusive upper bound.
+   * @returns Events within the range, preserving sort order.
+   */
+  public eventsInRange(startTime: MusicalTime, endTime: MusicalTime): readonly MusicEvent[] {
+    return this.#events.filter(
+      (event) =>
+        compareRationals(event.start, startTime) >= 0 && compareRationals(event.start, endTime) < 0,
+    );
+  }
+
+  /**
+   * Returns the total length of the sequence as a whole-note fraction,
+   * defined as `start + duration` of the latest-ending event.
+   * Returns `{ numerator: 0, denominator: 1 }` for an empty sequence.
+   *
+   * @returns The total duration.
+   */
+  public totalDuration(): MusicalDuration {
+    if (this.#events.length === 0) {
+      return { numerator: 0, denominator: 1 };
+    }
+
+    let max: Rational = { numerator: 0, denominator: 1 };
+
+    for (const event of this.#events) {
+      const end = addRationals(event.start, event.duration);
+
+      if (compareRationals(end, max) > 0) {
+        max = end;
+      }
+    }
+
+    return max;
+  }
+
+  /**
+   * Returns `true` when the sequence has no events.
+   *
+   * @returns `true` for an empty sequence.
+   */
+  public isEmpty(): boolean {
+    return this.#events.length === 0;
+  }
+
+  /**
+   * Returns `true` when another sequence has the same tempo, meter, and events.
+   *
+   * @param other The sequence to compare.
+   * @returns `true` when the sequences are equal.
+   */
+  public equals(other: Sequence): boolean {
+    if (this.#tempo !== other.tempo) return false;
+    if (!metersMatch(this.#meter, other.meter)) return false;
+    if (this.#events.length !== other.events.length) return false;
+
+    return this.#events.every((event, i) => {
+      const otherEvent = other.events[i];
+      return otherEvent !== undefined && eventsMatch(event, otherEvent);
+    });
+  }
+
+  /**
+   * Serializes the sequence to a JSON-safe value for deterministic storage and share links.
+   *
+   * Recreate with {@link Sequence.fromJSON}.
+   *
+   * @returns The serialized sequence.
+   */
+  public toJSON(): SerializedSequence {
+    const meter =
+      this.#meter !== null
+        ? { numerator: this.#meter.numerator, denominator: this.#meter.denominator }
+        : null;
+
+    return {
+      tempo: this.#tempo,
+      meter,
+      events: this.#events.map(serializeEvent),
+    };
+  }
+
+  /**
+   * Returns the custom `Object.prototype.toString` tag.
+   */
+  public get [Symbol.toStringTag](): string {
+    return `Sequence(${this.#events.length} event(s), ${this.#tempo} BPM)`;
+  }
+}

--- a/src/sequences/sequence.ts
+++ b/src/sequences/sequence.ts
@@ -99,7 +99,17 @@ function validateMusicalDuration(value: Rational): void {
   }
 }
 
+const EVENT_TYPES: ReadonlySet<string> = new Set(['note', 'chord', 'rest']);
+
 function validateEvent(event: MusicEvent): void {
+  // Trust boundary: in plain JS (or via casts) an unknown discriminant can reach
+  // create(). Reject it here rather than letting toJSON/transpose crash later.
+  if (!EVENT_TYPES.has(event.type)) {
+    throw new TypeError(
+      `Unknown music event type, received ${JSON.stringify((event as { type: unknown }).type)}.`,
+    );
+  }
+
   validateMusicalTime(event.start, 'start');
   validateMusicalDuration(event.duration);
 

--- a/src/sequences/sequence.ts
+++ b/src/sequences/sequence.ts
@@ -20,7 +20,7 @@ import {
   rationalsEqual,
   rationalToNumber,
 } from '../rational.js';
-import type { Meter } from '../meter.js';
+import { Meter } from '../meter.js';
 import { serializeEvent, deserializeEvent } from './serialization.js';
 import type {
   MusicEvent,
@@ -256,12 +256,14 @@ export class Sequence {
     }
 
     const events = serialized.events.map(deserializeEvent);
+
+    for (const event of events) {
+      validateEvent(event);
+    }
+
     const sorted = [...events].toSorted((a, b) => compareRationals(a.start, b.start));
 
-    // The meter shape { numerator, denominator } is compatible with Meter's
-    // public interface. Callers needing full Meter behaviour can reconstruct
-    // via Meter.fromJSON(sequence.meter).
-    const meter = serialized.meter as Meter | null;
+    const meter = serialized.meter !== null ? Meter.fromJSON(serialized.meter) : null;
 
     return createSequence(sorted, serialized.tempo, meter);
   }

--- a/src/sequences/sequence.ts
+++ b/src/sequences/sequence.ts
@@ -237,7 +237,8 @@ export class Sequence {
    *
    * @param serialized The serialized sequence.
    * @returns The recreated sequence.
-   * @throws {TypeError} When the serialized tempo is invalid.
+   * @throws {RangeError} When the serialized tempo is not a finite positive number.
+   * @throws {TypeError} When a serialized event has an unknown type.
    */
   public static fromJSON(serialized: SerializedSequence): Sequence {
     validateTempo(serialized.tempo);

--- a/src/sequences/sequence.ts
+++ b/src/sequences/sequence.ts
@@ -147,28 +147,17 @@ function transposeChordEvent(event: ChordEvent, interval: Interval): ChordEvent 
 // ---------------------------------------------------------------------------
 
 function metersMatch(a: Meter | null, b: Meter | null): boolean {
-  if ((a === null) !== (b === null)) return false;
+  if (a === null || b === null) return a === b;
 
-  if (a !== null && b !== null) {
-    return a.numerator === b.numerator && a.denominator === b.denominator;
-  }
-
-  return true;
+  return a.equals(b);
 }
 
 function noteEventsMatch(a: NoteEvent, b: NoteEvent): boolean {
-  return (
-    a.note.note === b.note.note && a.note.octave === b.note.octave && a.velocity === b.velocity
-  );
+  return a.note.equals(b.note) && a.velocity === b.velocity;
 }
 
 function chordEventsMatch(a: ChordEvent, b: ChordEvent): boolean {
-  return (
-    a.chord.root.note === b.chord.root.note &&
-    a.chord.root.octave === b.chord.root.octave &&
-    a.chord.suffix === b.chord.suffix &&
-    a.velocity === b.velocity
-  );
+  return a.chord.equals(b.chord) && a.velocity === b.velocity;
 }
 
 function eventsMatch(a: MusicEvent, b: MusicEvent): boolean {
@@ -215,7 +204,7 @@ export class Sequence {
       events: readonly MusicEvent[],
       tempo: number,
       meter: Meter | null,
-    ): Sequence => new Sequence(events, tempo, meter);
+    ): Sequence => new Sequence(Object.freeze([...events]), tempo, meter);
   }
 
   /**
@@ -251,9 +240,7 @@ export class Sequence {
    * @throws {TypeError} When the serialized tempo is invalid.
    */
   public static fromJSON(serialized: SerializedSequence): Sequence {
-    if (!Number.isFinite(serialized.tempo) || serialized.tempo <= 0) {
-      throw new TypeError(`Serialized tempo must be a finite positive number.`);
-    }
+    validateTempo(serialized.tempo);
 
     const events = serialized.events.map(deserializeEvent);
 

--- a/src/sequences/serialization.test.ts
+++ b/src/sequences/serialization.test.ts
@@ -158,6 +158,67 @@ describe('Sequence.toJSON / fromJSON', () => {
     expect(restored.equals(original)).toBe(true);
   });
 
+  it('round-trips an inverted chord, preserving the inversion index', () => {
+    const firstInversion = Chord.create(Note.create('C4'), 'maj7').invert();
+    expect(firstInversion.inversionIndex).toBe(1);
+
+    const original = Sequence.create(
+      [{ type: 'chord', chord: firstInversion, start: q(0, 1), duration: WHOLE }],
+      { tempo: 120 },
+    );
+
+    const restored = Sequence.fromJSON(original.toJSON());
+
+    expect(restored.equals(original)).toBe(true);
+    expect((restored.events[0] as ChordEvent).chord.inversionIndex).toBe(1);
+  });
+
+  it('omits the inversion field for a root-position chord', () => {
+    const seq = Sequence.create([chordEvent('C4', 'maj7', q(0, 1), WHOLE)], { tempo: 120 });
+    const serialized = seq.toJSON().events[0] as { inversion?: number };
+
+    expect(serialized.inversion).toBeUndefined();
+  });
+
+  it('throws RangeError for an out-of-range serialized chord inversion', () => {
+    expect(() =>
+      Sequence.fromJSON({
+        tempo: 120,
+        meter: null,
+        events: [
+          {
+            type: 'chord',
+            rootWithOctave: 'C4',
+            suffix: 'major',
+            // A major triad has 3 notes; inversion 9 is out of range.
+            inversion: 9,
+            start: q(0, 1),
+            duration: WHOLE,
+          },
+        ],
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('throws TypeError for a non-integer serialized chord inversion', () => {
+    expect(() =>
+      Sequence.fromJSON({
+        tempo: 120,
+        meter: null,
+        events: [
+          {
+            type: 'chord',
+            rootWithOctave: 'C4',
+            suffix: 'major',
+            inversion: 1.5,
+            start: q(0, 1),
+            duration: WHOLE,
+          },
+        ],
+      }),
+    ).toThrow(TypeError);
+  });
+
   it('serializes meter as null when absent', () => {
     const seq = Sequence.create([], { tempo: 120 });
     expect(seq.toJSON().meter).toBeNull();

--- a/src/sequences/serialization.test.ts
+++ b/src/sequences/serialization.test.ts
@@ -219,6 +219,25 @@ describe('Sequence.toJSON / fromJSON', () => {
     ).toThrow(TypeError);
   });
 
+  it('throws RangeError for a negative serialized chord inversion', () => {
+    expect(() =>
+      Sequence.fromJSON({
+        tempo: 120,
+        meter: null,
+        events: [
+          {
+            type: 'chord',
+            rootWithOctave: 'C4',
+            suffix: 'major',
+            inversion: -1,
+            start: q(0, 1),
+            duration: WHOLE,
+          },
+        ],
+      }),
+    ).toThrow(RangeError);
+  });
+
   it('serializes meter as null when absent', () => {
     const seq = Sequence.create([], { tempo: 120 });
     expect(seq.toJSON().meter).toBeNull();

--- a/src/sequences/serialization.test.ts
+++ b/src/sequences/serialization.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect } from 'bun:test';
+import { Sequence, musicalTime } from './sequence.js';
+import { Note } from '../note.js';
+import { Chord } from '../chord.js';
+import { Meter } from '../meter.js';
+import type { NoteEvent, ChordEvent } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures (shared shape with sequence.test.ts)
+// ---------------------------------------------------------------------------
+
+const q: typeof musicalTime = musicalTime; // quarter = 1/4
+const QUARTER = q(1, 4);
+const HALF = q(1, 2);
+const WHOLE = q(1, 1);
+
+function noteEvent(
+  noteName: string,
+  start: ReturnType<typeof q>,
+  duration: ReturnType<typeof q>,
+  velocity?: number,
+): NoteEvent {
+  const base: NoteEvent = {
+    type: 'note',
+    note: Note.create(noteName),
+    start,
+    duration,
+  };
+
+  if (velocity !== undefined) {
+    return { ...base, velocity };
+  }
+
+  return base;
+}
+
+function chordEvent(
+  root: string,
+  suffix: string,
+  start: ReturnType<typeof q>,
+  duration: ReturnType<typeof q>,
+  velocity?: number,
+): ChordEvent {
+  const base: ChordEvent = {
+    type: 'chord',
+    chord: Chord.create(Note.create(root), suffix),
+    start,
+    duration,
+  };
+
+  if (velocity !== undefined) {
+    return { ...base, velocity };
+  }
+
+  return base;
+}
+
+function restEvent(
+  start: ReturnType<typeof q>,
+  duration: ReturnType<typeof q>,
+): { type: 'rest'; start: ReturnType<typeof q>; duration: ReturnType<typeof q> } {
+  return { type: 'rest', start, duration };
+}
+
+// ---------------------------------------------------------------------------
+// Serialization round-trip
+// ---------------------------------------------------------------------------
+
+describe('Sequence.toJSON / fromJSON', () => {
+  it('round-trips a note event sequence', () => {
+    const original = Sequence.create(
+      [
+        noteEvent('C4', q(0, 1), QUARTER),
+        noteEvent('E4', QUARTER, QUARTER, 64),
+        restEvent(HALF, QUARTER),
+      ],
+      { tempo: 120 },
+    );
+
+    const json = original.toJSON();
+    const restored = Sequence.fromJSON(json);
+
+    expect(restored.equals(original)).toBe(true);
+  });
+
+  it('round-trips a chord event without velocity', () => {
+    const original = Sequence.create([chordEvent('C4', 'maj7', q(0, 1), WHOLE)], { tempo: 80 });
+
+    const json = original.toJSON();
+    const restored = Sequence.fromJSON(json);
+
+    expect(restored.equals(original)).toBe(true);
+  });
+
+  it('round-trips a chord event with velocity', () => {
+    const original = Sequence.create([chordEvent('G4', '', q(0, 1), HALF, 90)], { tempo: 120 });
+
+    const json = original.toJSON();
+    const restored = Sequence.fromJSON(json);
+
+    expect(restored.equals(original)).toBe(true);
+    expect((restored.events[0] as ChordEvent).velocity).toBe(90);
+  });
+
+  it('produces deterministic JSON', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const json1 = JSON.stringify(seq.toJSON());
+    const json2 = JSON.stringify(seq.toJSON());
+
+    expect(json1).toBe(json2);
+  });
+
+  it('throws RangeError for invalid tempo (zero) in fromJSON', () => {
+    expect(() => Sequence.fromJSON({ tempo: 0, meter: null, events: [] })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite tempo (NaN) in fromJSON', () => {
+    expect(() => Sequence.fromJSON({ tempo: NaN, meter: null, events: [] })).toThrow(RangeError);
+  });
+
+  it('throws TypeError for an unknown serialized event type', () => {
+    expect(() =>
+      Sequence.fromJSON({
+        tempo: 120,
+        meter: null,
+        // Unknown discriminant smuggled past the type system at the JSON boundary.
+        events: [{ type: 'glissando', start: q(0, 1), duration: QUARTER }] as never,
+      }),
+    ).toThrow(TypeError);
+  });
+
+  it('round-trips a mixed sequence with all event types, velocities, and meter', () => {
+    const meter = Meter.create('6/8');
+    const original = Sequence.create(
+      [
+        noteEvent('C4', q(0, 1), QUARTER, 80),
+        chordEvent('F4', 'maj7', QUARTER, HALF, 64),
+        restEvent(q(3, 4), QUARTER),
+      ],
+      { tempo: 120, meter },
+    );
+
+    const restored = Sequence.fromJSON(original.toJSON());
+
+    expect(restored.equals(original)).toBe(true);
+    expect(restored.meter).toBeInstanceOf(Meter);
+    expect(restored.meter?.numerator).toBe(6);
+    expect((restored.events[0] as NoteEvent).velocity).toBe(80);
+    expect((restored.events[1] as ChordEvent).velocity).toBe(64);
+    // suffix round-trips as the canonical form ('maj7' is an alias of 'majorSeventh').
+    expect((restored.events[1] as ChordEvent).chord.suffix).toBe('majorSeventh');
+  });
+
+  it('round-trips with a rest event', () => {
+    const original = Sequence.create([restEvent(q(0, 1), QUARTER)], { tempo: 120 });
+    const restored = Sequence.fromJSON(original.toJSON());
+
+    expect(restored.equals(original)).toBe(true);
+  });
+
+  it('serializes meter as null when absent', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    expect(seq.toJSON().meter).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// equals
+// ---------------------------------------------------------------------------
+
+describe('Sequence.equals', () => {
+  it('considers two empty sequences with same tempo equal', () => {
+    const a = Sequence.create([], { tempo: 120 });
+    const b = Sequence.create([], { tempo: 120 });
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it('considers two sequences unequal when tempos differ', () => {
+    const a = Sequence.create([], { tempo: 120 });
+    const b = Sequence.create([], { tempo: 96 });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers two sequences unequal when event counts differ', () => {
+    const a = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const b = Sequence.create([], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers two sequences unequal when event types differ at the same position', () => {
+    const a = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const b = Sequence.create([restEvent(q(0, 1), QUARTER)], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers two sequences unequal when note names differ', () => {
+    const a = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const b = Sequence.create([noteEvent('D4', q(0, 1), QUARTER)], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers two sequences unequal when note velocities differ', () => {
+    const a = Sequence.create([noteEvent('C4', q(0, 1), QUARTER, 80)], { tempo: 120 });
+    const b = Sequence.create([noteEvent('C4', q(0, 1), QUARTER, 90)], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers two sequences unequal when event start times differ', () => {
+    const a = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const b = Sequence.create([noteEvent('C4', QUARTER, QUARTER)], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers two sequences unequal when event durations differ', () => {
+    const a = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    const b = Sequence.create([noteEvent('C4', q(0, 1), HALF)], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers two sequences unequal when chord suffixes differ', () => {
+    const a = Sequence.create([chordEvent('C4', 'maj7', q(0, 1), WHOLE)], { tempo: 120 });
+    const b = Sequence.create([chordEvent('C4', '', q(0, 1), WHOLE)], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers two sequences unequal when chord inversions differ', () => {
+    const rootPosition: ChordEvent = {
+      type: 'chord',
+      chord: Chord.create(Note.create('C4'), 'maj7'),
+      start: q(0, 1),
+      duration: WHOLE,
+    };
+    const firstInversion: ChordEvent = {
+      type: 'chord',
+      chord: Chord.create(Note.create('C4'), 'maj7').invert(),
+      start: q(0, 1),
+      duration: WHOLE,
+    };
+    const a = Sequence.create([rootPosition], { tempo: 120 });
+    const b = Sequence.create([firstInversion], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Symbol.toStringTag
+// ---------------------------------------------------------------------------
+
+describe('Sequence[Symbol.toStringTag]', () => {
+  it('returns a descriptive tag', () => {
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120 });
+    expect(seq[Symbol.toStringTag]).toBe('Sequence(1 event(s), 120 BPM)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Meter option
+// ---------------------------------------------------------------------------
+
+describe('Sequence with meter', () => {
+  it('stores the meter when provided', () => {
+    const meter = Meter.create('4/4');
+    const seq = Sequence.create([], { tempo: 120, meter });
+    expect(seq.meter).not.toBeNull();
+    expect(seq.meter?.numerator).toBe(4);
+    expect(seq.meter?.denominator).toBe(4);
+  });
+
+  it('uses meter.beatUnit for toAbsoluteSeconds in 4/4', () => {
+    // 4/4: beatUnit = 1/4; quarter note at 120 BPM = 0.5s (same as no-meter)
+    const meter = Meter.create('4/4');
+    const seq = Sequence.create([noteEvent('C4', QUARTER, QUARTER)], { tempo: 120, meter });
+    const [timed] = seq.toAbsoluteSeconds();
+    expect(timed?.startSeconds).toBeCloseTo(0.5);
+    expect(timed?.durationSeconds).toBeCloseTo(0.5);
+  });
+
+  it('uses meter.beatUnit for toAbsoluteSeconds in 6/8 (compound)', () => {
+    // 6/8: beatUnit = 3/8; dotted quarter = 3/8 = one beat at 120 BPM → 0.5s
+    const meter = Meter.create('6/8');
+    const dottedQuarter = q(3, 8);
+    const seq = Sequence.create([noteEvent('C4', dottedQuarter, dottedQuarter)], {
+      tempo: 120,
+      meter,
+    });
+    const [timed] = seq.toAbsoluteSeconds();
+    // start = 3/8 beat; beatUnit = 3/8 → 1 beat → 0.5s
+    expect(timed?.startSeconds).toBeCloseTo(0.5);
+    expect(timed?.durationSeconds).toBeCloseTo(0.5);
+  });
+
+  it('round-trips a sequence with meter via toJSON/fromJSON', () => {
+    const meter = Meter.create('6/8');
+    const original = Sequence.create([noteEvent('C4', q(0, 1), q(3, 8))], { tempo: 120, meter });
+
+    const json = original.toJSON();
+    const restored = Sequence.fromJSON(json);
+
+    // meter must be a real Meter instance with beatUnit
+    expect(restored.meter).not.toBeNull();
+    expect(restored.meter).toBeInstanceOf(Meter);
+    expect(restored.meter?.numerator).toBe(6);
+    expect(restored.meter?.denominator).toBe(8);
+    expect(restored.equals(original)).toBe(true);
+  });
+
+  it('toAbsoluteSeconds works correctly after fromJSON with meter', () => {
+    const meter = Meter.create('6/8');
+    const dottedQuarter = q(3, 8);
+    const original = Sequence.create([noteEvent('C4', dottedQuarter, dottedQuarter)], {
+      tempo: 120,
+      meter,
+    });
+
+    const restored = Sequence.fromJSON(original.toJSON());
+    const [timed] = restored.toAbsoluteSeconds();
+
+    // Should use meter.beatUnit = 3/8; dotted quarter at 120 BPM → 0.5s
+    expect(timed?.startSeconds).toBeCloseTo(0.5);
+    expect(timed?.durationSeconds).toBeCloseTo(0.5);
+  });
+
+  it('preserves meter after transpose', () => {
+    const meter = Meter.create('3/4');
+    const seq = Sequence.create([noteEvent('C4', q(0, 1), QUARTER)], { tempo: 120, meter });
+    const transposed = seq.transpose('majorSecond');
+
+    expect(transposed.meter).not.toBeNull();
+    expect(transposed.meter?.numerator).toBe(3);
+    expect(transposed.meter?.denominator).toBe(4);
+  });
+
+  it('considers two sequences with same meter equal', () => {
+    const meter = Meter.create('3/4');
+    const a = Sequence.create([], { tempo: 120, meter });
+    const b = Sequence.create([], { tempo: 120, meter: Meter.create('3/4') });
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it('considers two sequences unequal when meters differ', () => {
+    const a = Sequence.create([], { tempo: 120, meter: Meter.create('4/4') });
+    const b = Sequence.create([], { tempo: 120, meter: Meter.create('3/4') });
+    expect(a.equals(b)).toBe(false);
+  });
+
+  it('considers sequence with meter unequal to one without', () => {
+    const a = Sequence.create([], { tempo: 120, meter: Meter.create('4/4') });
+    const b = Sequence.create([], { tempo: 120 });
+    expect(a.equals(b)).toBe(false);
+  });
+});

--- a/src/sequences/serialization.ts
+++ b/src/sequences/serialization.ts
@@ -1,0 +1,111 @@
+/**
+ * Serialization and deserialization helpers for music events.
+ *
+ * Internal module — not exported from the subpath root.
+ */
+
+import { Note, type NoteLike } from '../note.js';
+import { Chord } from '../chord.js';
+import type { ChordSuffix } from '../chords.js';
+import type {
+  MusicEvent,
+  NoteEvent,
+  ChordEvent,
+  SerializedMusicEvent,
+  SerializedNoteEvent,
+  SerializedChordEvent,
+} from './types.js';
+
+/**
+ * Converts a {@link MusicEvent} to a JSON-safe representation.
+ *
+ * @param event The event to serialize.
+ * @returns The serialized event.
+ */
+export function serializeEvent(event: MusicEvent): SerializedMusicEvent {
+  if (event.type === 'rest') {
+    return { type: 'rest', start: event.start, duration: event.duration };
+  }
+
+  if (event.type === 'note') {
+    return serializeNoteEvent(event);
+  }
+
+  return serializeChordEvent(event);
+}
+
+function serializeNoteEvent(event: NoteEvent): SerializedNoteEvent {
+  const base: SerializedNoteEvent = {
+    type: 'note',
+    noteWithOctave: `${event.note.note}${event.note.octave}`,
+    start: event.start,
+    duration: event.duration,
+  };
+
+  if (event.velocity !== undefined) {
+    return { ...base, velocity: event.velocity };
+  }
+
+  return base;
+}
+
+function serializeChordEvent(event: ChordEvent): SerializedChordEvent {
+  const base: SerializedChordEvent = {
+    type: 'chord',
+    rootWithOctave: `${event.chord.root.note}${event.chord.root.octave}`,
+    suffix: event.chord.suffix,
+    start: event.start,
+    duration: event.duration,
+  };
+
+  if (event.velocity !== undefined) {
+    return { ...base, velocity: event.velocity };
+  }
+
+  return base;
+}
+
+/**
+ * Recreates a {@link MusicEvent} from its serialized form.
+ *
+ * @param raw The serialized event.
+ * @returns The deserialized event.
+ */
+export function deserializeEvent(raw: SerializedMusicEvent): MusicEvent {
+  if (raw.type === 'rest') {
+    return { type: 'rest', start: raw.start, duration: raw.duration };
+  }
+
+  if (raw.type === 'note') {
+    return deserializeNoteEvent(raw);
+  }
+
+  return deserializeChordEvent(raw);
+}
+
+function deserializeNoteEvent(raw: SerializedNoteEvent): NoteEvent {
+  // noteWithOctave is a string matching `${NoteName}${Octave}` produced by
+  // serializeEvent — the runtime value is always a valid NoteNameWithOctave.
+  const note = Note.create(raw.noteWithOctave as NoteLike);
+  const base: NoteEvent = { type: 'note', note, start: raw.start, duration: raw.duration };
+
+  if (raw.velocity !== undefined) {
+    return { ...base, velocity: raw.velocity };
+  }
+
+  return base;
+}
+
+function deserializeChordEvent(raw: SerializedChordEvent): ChordEvent {
+  // rootWithOctave is produced by serializeEvent — always a valid NoteNameWithOctave.
+  const root = Note.create(raw.rootWithOctave as NoteLike);
+  // suffix is the canonical ChordSuffix string stored by the Chord class.
+  const chord = Chord.create(root, raw.suffix as ChordSuffix);
+  const base: ChordEvent = { type: 'chord', chord, start: raw.start, duration: raw.duration };
+
+  if (raw.velocity !== undefined) {
+    return { ...base, velocity: raw.velocity };
+  }
+
+  return base;
+}

--- a/src/sequences/serialization.ts
+++ b/src/sequences/serialization.ts
@@ -139,17 +139,17 @@ function applyInversion(chord: Chord, inversion: number | undefined): Chord {
     return chord;
   }
 
-  if (!Number.isInteger(inversion) || inversion < 0) {
-    throw new TypeError(
-      `Serialized chord inversion must be a non-negative integer, received ${inversion}.`,
-    );
+  // Shape vs. bounds, per the error taxonomy: a non-integer is a type error,
+  // an out-of-range integer is a range error.
+  if (!Number.isInteger(inversion)) {
+    throw new TypeError(`Serialized chord inversion must be an integer, received ${inversion}.`);
   }
 
-  // Chord.invert wraps modulo the note count; guard the upper bound explicitly so
-  // an out-of-range serialized index is rejected rather than silently wrapped.
-  if (inversion >= chord.notes.length) {
+  // Chord.invert wraps modulo the note count; guard both bounds explicitly so an
+  // out-of-range serialized index is rejected rather than silently wrapped.
+  if (inversion < 0 || inversion >= chord.notes.length) {
     throw new RangeError(
-      `Serialized chord inversion ${inversion} exceeds the ${chord.notes.length}-note chord.`,
+      `Serialized chord inversion ${inversion} is out of range for the ${chord.notes.length}-note chord.`,
     );
   }
 

--- a/src/sequences/serialization.ts
+++ b/src/sequences/serialization.ts
@@ -80,7 +80,16 @@ export function deserializeEvent(raw: SerializedMusicEvent): MusicEvent {
     return deserializeNoteEvent(raw);
   }
 
-  return deserializeChordEvent(raw);
+  if (raw.type === 'chord') {
+    return deserializeChordEvent(raw);
+  }
+
+  // Trust boundary: a serialized event from external JSON may carry an
+  // unknown discriminant. Reject it explicitly rather than mis-deserializing
+  // it as a chord.
+  throw new TypeError(
+    `Unknown serialized event type, received ${JSON.stringify((raw as { type: unknown }).type)}.`,
+  );
 }
 
 function deserializeNoteEvent(raw: SerializedNoteEvent): NoteEvent {

--- a/src/sequences/serialization.ts
+++ b/src/sequences/serialization.ts
@@ -131,8 +131,8 @@ function deserializeChordEvent(raw: SerializedChordEvent): ChordEvent {
  * @param chord The root-position chord.
  * @param inversion The serialized inversion index, or `undefined` for root position.
  * @returns The chord at the requested inversion.
- * @throws {TypeError} When the inversion is not a non-negative integer.
- * @throws {RangeError} When the inversion exceeds the chord's note count.
+ * @throws {TypeError} When the inversion is not an integer.
+ * @throws {RangeError} When the inversion is negative or exceeds the chord's note count.
  */
 function applyInversion(chord: Chord, inversion: number | undefined): Chord {
   if (inversion === undefined || inversion === 0) {

--- a/src/sequences/serialization.ts
+++ b/src/sequences/serialization.ts
@@ -50,13 +50,19 @@ function serializeNoteEvent(event: NoteEvent): SerializedNoteEvent {
 }
 
 function serializeChordEvent(event: ChordEvent): SerializedChordEvent {
-  const base: SerializedChordEvent = {
+  let base: SerializedChordEvent = {
     type: 'chord',
     rootWithOctave: `${event.chord.root.note}${event.chord.root.octave}`,
     suffix: event.chord.suffix,
     start: event.start,
     duration: event.duration,
   };
+
+  // Root position (inversion 0) is the default — omit the field to keep the JSON
+  // minimal and mirror the optional-velocity pattern.
+  if (event.chord.inversionIndex > 0) {
+    base = { ...base, inversion: event.chord.inversionIndex };
+  }
 
   if (event.velocity !== undefined) {
     return { ...base, velocity: event.velocity };
@@ -109,7 +115,7 @@ function deserializeChordEvent(raw: SerializedChordEvent): ChordEvent {
   // rootWithOctave is produced by serializeEvent — always a valid NoteNameWithOctave.
   const root = Note.create(raw.rootWithOctave as NoteLike);
   // suffix is the canonical ChordSuffix string stored by the Chord class.
-  const chord = Chord.create(root, raw.suffix as ChordSuffix);
+  const chord = applyInversion(Chord.create(root, raw.suffix as ChordSuffix), raw.inversion);
   const base: ChordEvent = { type: 'chord', chord, start: raw.start, duration: raw.duration };
 
   if (raw.velocity !== undefined) {
@@ -117,4 +123,35 @@ function deserializeChordEvent(raw: SerializedChordEvent): ChordEvent {
   }
 
   return base;
+}
+
+/**
+ * Reapplies a serialized inversion index to a freshly-created root-position chord.
+ *
+ * @param chord The root-position chord.
+ * @param inversion The serialized inversion index, or `undefined` for root position.
+ * @returns The chord at the requested inversion.
+ * @throws {TypeError} When the inversion is not a non-negative integer.
+ * @throws {RangeError} When the inversion exceeds the chord's note count.
+ */
+function applyInversion(chord: Chord, inversion: number | undefined): Chord {
+  if (inversion === undefined || inversion === 0) {
+    return chord;
+  }
+
+  if (!Number.isInteger(inversion) || inversion < 0) {
+    throw new TypeError(
+      `Serialized chord inversion must be a non-negative integer, received ${inversion}.`,
+    );
+  }
+
+  // Chord.invert wraps modulo the note count; guard the upper bound explicitly so
+  // an out-of-range serialized index is rejected rather than silently wrapped.
+  if (inversion >= chord.notes.length) {
+    throw new RangeError(
+      `Serialized chord inversion ${inversion} exceeds the ${chord.notes.length}-note chord.`,
+    );
+  }
+
+  return chord.invert(inversion);
 }

--- a/src/sequences/types.ts
+++ b/src/sequences/types.ts
@@ -143,6 +143,8 @@ export type SerializedChordEvent = {
   readonly rootWithOctave: string;
   /** Canonical chord suffix (the resolved catalog key, e.g. `"majorSeventh"`, not the `"maj7"` alias). */
   readonly suffix: string;
+  /** Inversion index. Absent means root position (inversion 0). */
+  readonly inversion?: number;
   readonly start: Rational;
   readonly duration: Rational;
   readonly velocity?: number;

--- a/src/sequences/types.ts
+++ b/src/sequences/types.ts
@@ -1,0 +1,171 @@
+/**
+ * Domain types for timed music events and sequences.
+ *
+ * Imported internally by `sequence.ts` and re-exported from `index.ts`.
+ */
+
+import type { Note } from '../note.js';
+import type { Chord } from '../chord.js';
+import type { Interval } from '../intervals.js';
+import type { Rational } from '../rational.js';
+import type { Meter } from '../meter.js';
+
+export type { Note, Chord, Interval, Rational, Meter };
+
+// ---------------------------------------------------------------------------
+// MusicalTime / MusicalDuration
+// ---------------------------------------------------------------------------
+
+/**
+ * A position within a sequence, expressed as a whole-note fraction from the
+ * sequence start. E.g. `{ numerator: 1, denominator: 4 }` = one quarter note.
+ */
+export type MusicalTime = Rational;
+
+/**
+ * A duration expressed as a whole-note fraction. Identical to {@link Rational}
+ * in representation — the alias communicates semantic intent.
+ */
+export type MusicalDuration = Rational;
+
+// ---------------------------------------------------------------------------
+// MusicEvent discriminated union
+// ---------------------------------------------------------------------------
+
+/**
+ * A sounding note event within a sequence.
+ */
+export type NoteEvent = {
+  /** Discriminant. */
+  readonly type: 'note';
+  /** The note to play. */
+  readonly note: Note;
+  /** Start offset from the sequence start, as a whole-note fraction. */
+  readonly start: MusicalTime;
+  /** Duration as a whole-note fraction. */
+  readonly duration: MusicalDuration;
+  /**
+   * MIDI velocity in 0..127. Absent means "use a default / unspecified".
+   * Declared optional with exactOptionalPropertyTypes: property is absent, not `undefined`.
+   */
+  readonly velocity?: number;
+};
+
+/**
+ * A sounding chord event within a sequence.
+ */
+export type ChordEvent = {
+  /** Discriminant. */
+  readonly type: 'chord';
+  /** The chord to play. */
+  readonly chord: Chord;
+  /** Start offset from the sequence start, as a whole-note fraction. */
+  readonly start: MusicalTime;
+  /** Duration as a whole-note fraction. */
+  readonly duration: MusicalDuration;
+  /** MIDI velocity in 0..127. */
+  readonly velocity?: number;
+};
+
+/**
+ * A rest (silence) within a sequence.
+ */
+export type RestEvent = {
+  /** Discriminant. */
+  readonly type: 'rest';
+  /** Start offset from the sequence start, as a whole-note fraction. */
+  readonly start: MusicalTime;
+  /** Duration as a whole-note fraction. */
+  readonly duration: MusicalDuration;
+};
+
+/**
+ * A discriminated union of all timed events that can appear in a {@link Sequence}.
+ */
+export type MusicEvent = NoteEvent | ChordEvent | RestEvent;
+
+// ---------------------------------------------------------------------------
+// Absolute-time output
+// ---------------------------------------------------------------------------
+
+/**
+ * A {@link NoteEvent} enriched with real-time positions.
+ */
+export type TimedNoteEvent = NoteEvent & {
+  readonly startSeconds: number;
+  readonly durationSeconds: number;
+};
+
+/**
+ * A {@link ChordEvent} enriched with real-time positions.
+ */
+export type TimedChordEvent = ChordEvent & {
+  readonly startSeconds: number;
+  readonly durationSeconds: number;
+};
+
+/**
+ * A {@link RestEvent} enriched with real-time positions.
+ */
+export type TimedRestEvent = RestEvent & {
+  readonly startSeconds: number;
+  readonly durationSeconds: number;
+};
+
+/** A {@link MusicEvent} enriched with absolute real-time positions. */
+export type TimedMusicEvent = TimedNoteEvent | TimedChordEvent | TimedRestEvent;
+
+// ---------------------------------------------------------------------------
+// Sequence options and serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link Sequence.create}.
+ */
+export type SequenceOptions = {
+  /** Tempo in BPM. Must be a finite positive number. */
+  readonly tempo: number;
+  /** Time signature. When absent, assumes a quarter-note beat unit (standard 4/4 feel). */
+  readonly meter?: Meter;
+};
+
+/** Serialized form of a note event. */
+export type SerializedNoteEvent = {
+  readonly type: 'note';
+  /** Combined note-name-with-octave, e.g. `"C4"` or `"Bb-1"`. */
+  readonly noteWithOctave: string;
+  readonly start: Rational;
+  readonly duration: Rational;
+  readonly velocity?: number;
+};
+
+/** Serialized form of a chord event. */
+export type SerializedChordEvent = {
+  readonly type: 'chord';
+  /** Root note-name-with-octave, e.g. `"C4"`. */
+  readonly rootWithOctave: string;
+  /** Canonical chord suffix, e.g. `"maj7"`. */
+  readonly suffix: string;
+  readonly start: Rational;
+  readonly duration: Rational;
+  readonly velocity?: number;
+};
+
+/** Serialized form of a rest event. */
+export type SerializedRestEvent = {
+  readonly type: 'rest';
+  readonly start: Rational;
+  readonly duration: Rational;
+};
+
+/** Serialized form of any music event. */
+export type SerializedMusicEvent = SerializedNoteEvent | SerializedChordEvent | SerializedRestEvent;
+
+/**
+ * A JSON-serializable snapshot of a {@link Sequence}.
+ */
+export type SerializedSequence = {
+  readonly tempo: number;
+  readonly meter: { readonly numerator: number; readonly denominator: number } | null;
+  readonly events: readonly SerializedMusicEvent[];
+};

--- a/src/sequences/types.ts
+++ b/src/sequences/types.ts
@@ -6,11 +6,8 @@
 
 import type { Note } from '../note.js';
 import type { Chord } from '../chord.js';
-import type { Interval } from '../intervals.js';
 import type { Rational } from '../rational.js';
 import type { Meter } from '../meter.js';
-
-export type { Note, Chord, Interval, Rational, Meter };
 
 // ---------------------------------------------------------------------------
 // MusicalTime / MusicalDuration
@@ -144,7 +141,7 @@ export type SerializedChordEvent = {
   readonly type: 'chord';
   /** Root note-name-with-octave, e.g. `"C4"`. */
   readonly rootWithOctave: string;
-  /** Canonical chord suffix, e.g. `"maj7"`. */
+  /** Canonical chord suffix (the resolved catalog key, e.g. `"majorSeventh"`, not the `"maj7"` alias). */
   readonly suffix: string;
   readonly start: Rational;
   readonly duration: Rational;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsdown';
 
+// Each subpath export gets its own entry point here.
+// Convention: add 'src/<name>/index.ts' to the entry array and a matching
+// "./name" condition to package.json exports (types + browser/import/default).
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/sequences/index.ts'],
   outDir: 'dist/browser',
   format: 'esm',
   outExtensions: () => ({ js: '.js' }),

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from 'tsdown';
 
 // Each subpath export gets its own entry point here.
-// Convention: add 'src/<name>/index.ts' to the entry array and a matching
-// "./name" condition to package.json exports (types + browser/import/default).
+// Convention: add 'src/<name>/index.ts' to the entry array, a matching
+// "./name" condition to package.json exports (types + browser/import/default),
+// and a runtime assertion in scripts/smoke-checks.mjs wired into
+// scripts/smoke-consumer-check.mjs so the tarball smoke test covers it.
 export default defineConfig({
   entry: ['src/index.ts', 'src/sequences/index.ts'],
   outDir: 'dist/browser',


### PR DESCRIPTION
## Summary

Wave D foundation: introduces the package's **first subpath export**, `octavian/sequences`, alongside the existing root export `octavian`. This change defines the convention every future subpath module (#27, #31, #33, #37, #38, plus the browser adapters #32) will follow, so it was reviewed as the export-surface-defining change it is.

Closes #34 (subpath export scaffolding) and #30 (timed music-event + sequence primitives).

### What's in it

- **`octavian/sequences`** — a `Sequence` value object: timed `MusicEvent`s (note/chord/rest as a discriminated union), musical time as rational fractions, tempo→seconds conversion, `transpose`, `eventsInRange`, `totalDuration`, `equals`, and JSON round-trip. `musicalTime(n, d)` helper. Public API: `Sequence`, `musicalTime`.
- **Build scaffolding** — `tsdown.config.ts` entry array, a `./sequences` block in the `package.json` `exports` map (types-first), and `validate-artifacts.ts` extended to glob **all** `dist/browser/**/*.js` and `dist/**/*.d.ts` for forbidden Node/Bun globals.
- **Isolation invariant** — the root barrel (`src/index.ts`) does **not** re-export anything from `octavian/sequences`. Verified: `Sequence`/`musicalTime` are absent from the 173-symbol root export; the subpath resolves to its own bundle.
- **Convention, documented in code** — `tsdown.config.ts` + `sequences/index.ts` + `smoke-checks.mjs` spell out the steps to add a subpath (entry → exports block → runtime smoke assertion), including a note that **browser-only adapter subpaths** (Web Audio/MIDI) must not touch browser globals at import time and must use existence-only smoke assertions (the tarball smoke test runs under Bun).

## Verification

- `bun run validate` green: format, lint, typecheck, typecheck:test, **2230 tests**, build, `publint` + `attw` (both `.` and `./sequences` resolve 🟢 for `node16` ESM and `bundler`), artifact validation across all 3 browser bundles, and the **tarball smoke test** — which now imports `octavian/sequences` through the exports map from a fresh consumer install.
- Non-parallel coverage (the reliable signal): `src/sequences/{index,sequence,serialization}.ts` are each **100% lines + functions**.

## Review committee

Ran the full committee before opening this PR: **typescript-expert, simplicity-engineer, dx-engineer, testing-expert, and Codex (xhigh)**. Three rounds; consensus reached. Bugs the committee caught that all passed their own 100%-coverage tests:

1. **`chordEventsMatch` ignored chord inversion** → two sequences whose chords differed only by inversion compared *equal*. Fixed by delegating equality to `Note.equals`/`Chord.equals`/`Meter.equals`.
2. **Inverted-chord serialization lost the inversion** (surfaced by fix #1) → `seq.equals(fromJSON(toJSON(seq)))` was `false` for any inverted chord. Fixed: `SerializedChordEvent` now carries an optional `inversion`, reapplied through a guarded `applyInversion` (TypeError for non-integer, RangeError for out-of-range, instead of `Chord.invert` silently wrapping mod note-count).
3. **`fromJSON` threw `TypeError` for an invalid tempo** → should be `RangeError` per the numeric-bounds taxonomy (matches sibling `Meter.fromJSON`). Now routed through the shared `validateTempo`.
4. **`deserializeEvent` treated any unknown discriminant as a chord** → now throws `TypeError` at the trust boundary.

Also adopted: frozen `events` array (matching `Melody`'s `Object.freeze`), dead-export removal, `collectFiles` dedup, and a broad set of added branch tests (velocity boundaries/non-integer, validator TypeError arms, non-finite tempo on create+fromJSON, full `equals` content-differ matrix).

## Note (pre-existing, not introduced here)

`src/cadence.ts` reports **99.36% line coverage on clean `main`** as well — it's a pre-existing gap, out of scope for this foundation PR, and untouched here. Flagging it for visibility rather than silently folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
