### PR TITLE
feat: notation, pitch, midi, midi-file, perf-timing subpaths (#27, #33, #31, #38, #37)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,36 @@
       "import": "./dist/browser/sequences/index.js",
       "default": "./dist/browser/sequences/index.js"
     },
+    "./notation": {
+      "types": "./dist/notation/index.d.ts",
+      "browser": "./dist/browser/notation/index.js",
+      "import": "./dist/browser/notation/index.js",
+      "default": "./dist/browser/notation/index.js"
+    },
+    "./pitch": {
+      "types": "./dist/pitch/index.d.ts",
+      "browser": "./dist/browser/pitch/index.js",
+      "import": "./dist/browser/pitch/index.js",
+      "default": "./dist/browser/pitch/index.js"
+    },
+    "./midi": {
+      "types": "./dist/midi/index.d.ts",
+      "browser": "./dist/browser/midi/index.js",
+      "import": "./dist/browser/midi/index.js",
+      "default": "./dist/browser/midi/index.js"
+    },
+    "./midi-file": {
+      "types": "./dist/midi-file/index.d.ts",
+      "browser": "./dist/browser/midi-file/index.js",
+      "import": "./dist/browser/midi-file/index.js",
+      "default": "./dist/browser/midi-file/index.js"
+    },
+    "./perf-timing": {
+      "types": "./dist/performance-timing/index.d.ts",
+      "browser": "./dist/browser/performance-timing/index.js",
+      "import": "./dist/browser/performance-timing/index.js",
+      "default": "./dist/browser/performance-timing/index.js"
+    },
     "./package.json": "./package.json"
   },
   "types": "./dist/index.d.ts",

--- a/scripts/smoke-checks.mjs
+++ b/scripts/smoke-checks.mjs
@@ -51,3 +51,68 @@ export function assertSequencesSmokeChecks(sequences) {
   );
   if (seq.events.length !== 1) throw new Error('octavian/sequences: Sequence.create broken');
 }
+
+export function assertNotationSmokeChecks(notation) {
+  if (typeof notation.staffPositionFor !== 'function') {
+    throw new Error('octavian/notation: staffPositionFor missing');
+  }
+  if (typeof notation.accidentalForDisplay !== 'function') {
+    throw new Error('octavian/notation: accidentalForDisplay missing');
+  }
+  // Ground truth: middle C (C4) sits on the first ledger line below the treble staff.
+  const position = notation.staffPositionFor('C4', 'treble');
+  if (position.ledgerLines !== 1) {
+    throw new Error('octavian/notation: staffPositionFor(C4, treble) ledgerLines broken');
+  }
+}
+
+export function assertPitchSmokeChecks(pitch) {
+  if (typeof pitch.evaluatePitchEstimate !== 'function') {
+    throw new Error('octavian/pitch: evaluatePitchEstimate missing');
+  }
+  // Ground truth: a 440 Hz estimate against A4 is exactly on pitch (0 cents).
+  const evaluation = pitch.evaluatePitchEstimate({ frequency: 440 }, 'A4');
+  if (Math.abs(evaluation.centsError) > 0.001) {
+    throw new Error('octavian/pitch: evaluatePitchEstimate centsError broken');
+  }
+}
+
+export function assertMidiSmokeChecks(midi) {
+  if (typeof midi.parseMidiMessage !== 'function') {
+    throw new Error('octavian/midi: parseMidiMessage missing');
+  }
+  // Ground truth: 0x90 status, note 60, velocity 100 is a note-on for MIDI key 60.
+  const message = midi.parseMidiMessage([0x90, 60, 100]);
+  if (message.type !== 'noteOn' || message.note !== 60) {
+    throw new Error('octavian/midi: parseMidiMessage broken');
+  }
+}
+
+export function assertMidiFileSmokeChecks(midiFile, sequences) {
+  if (typeof midiFile.sequenceToMidiFile !== 'function') {
+    throw new Error('octavian/midi-file: sequenceToMidiFile missing');
+  }
+  // Ground truth: a serialized SMF begins with the ASCII 'MThd' header chunk.
+  const seq = sequences.Sequence.create(
+    [{ type: 'rest', start: sequences.musicalTime(0, 1), duration: sequences.musicalTime(1, 4) }],
+    { tempo: 120 },
+  );
+  const bytes = midiFile.sequenceToMidiFile(seq);
+  if (bytes[0] !== 0x4d || bytes[1] !== 0x54 || bytes[2] !== 0x68 || bytes[3] !== 0x64) {
+    throw new Error('octavian/midi-file: sequenceToMidiFile MThd header broken');
+  }
+}
+
+export function assertPerfTimingSmokeChecks(perfTiming) {
+  if (typeof perfTiming.estimateTempoFromOnsets !== 'function') {
+    throw new Error('octavian/perf-timing: estimateTempoFromOnsets missing');
+  }
+  if (typeof perfTiming.classifyTimingError !== 'function') {
+    throw new Error('octavian/perf-timing: classifyTimingError missing');
+  }
+  // Ground truth: onsets a half-second apart imply 120 BPM.
+  const estimate = perfTiming.estimateTempoFromOnsets([0, 0.5, 1.0, 1.5]);
+  if (!estimate || Math.abs(estimate.bpm - 120) > 0.001) {
+    throw new Error('octavian/perf-timing: estimateTempoFromOnsets broken');
+  }
+}

--- a/scripts/smoke-consumer-check.mjs
+++ b/scripts/smoke-consumer-check.mjs
@@ -2,13 +2,36 @@
 // project alongside _smoke-checks.mjs and executed via bun. Imports the package
 // by name so resolution goes through the consumer's node_modules (exercises the
 // exports map). Assertions live in _smoke-checks.mjs — single source of truth.
-import { assertSmokeChecks, assertSequencesSmokeChecks } from './_smoke-checks.mjs';
+import {
+  assertSmokeChecks,
+  assertSequencesSmokeChecks,
+  assertNotationSmokeChecks,
+  assertPitchSmokeChecks,
+  assertMidiSmokeChecks,
+  assertMidiFileSmokeChecks,
+  assertPerfTimingSmokeChecks,
+} from './_smoke-checks.mjs';
 
 const octavian = await import('octavian');
 assertSmokeChecks(octavian);
 
-// Resolve the octavian/sequences subpath through the consumer's exports map.
+// Resolve each subpath through the consumer's exports map.
 const sequences = await import('octavian/sequences');
 assertSequencesSmokeChecks(sequences);
+
+const notation = await import('octavian/notation');
+assertNotationSmokeChecks(notation);
+
+const pitch = await import('octavian/pitch');
+assertPitchSmokeChecks(pitch);
+
+const midi = await import('octavian/midi');
+assertMidiSmokeChecks(midi);
+
+const midiFile = await import('octavian/midi-file');
+assertMidiFileSmokeChecks(midiFile, sequences);
+
+const perfTiming = await import('octavian/perf-timing');
+assertPerfTimingSmokeChecks(perfTiming);
 
 process.stdout.write('tarball smoke test passed\n');

--- a/src/midi-file/decode.ts
+++ b/src/midi-file/decode.ts
@@ -56,6 +56,36 @@ type ParseMetaResult = {
   readonly event: MidiTrackEvent;
 };
 
+/**
+ * Decodes a meta event's length VLQ, ensuring the length field itself stays
+ * within the track. A meta event whose length byte is missing (the track ends
+ * right after `FF <type>`), or whose multi-byte VLQ runs past the track end,
+ * must be rejected rather than borrowing bytes from the next chunk.
+ *
+ * @returns The decoded `metaLength` and the cursor positioned at the payload.
+ * @throws {RangeError} When the length field lies outside the track.
+ */
+function decodeMetaLength(
+  data: Uint8Array,
+  cursor: number,
+  end: number,
+): { readonly metaLength: number; readonly cursor: number } {
+  if (cursor >= end) {
+    throw new RangeError(`Truncated meta event length at offset ${cursor}.`);
+  }
+
+  const { value: metaLength, bytesRead } = decodeVlq(data, cursor);
+  const next = cursor + bytesRead;
+
+  if (next > end) {
+    throw new RangeError(
+      `Meta event length field at offset ${cursor} exceeds track boundary ${end}.`,
+    );
+  }
+
+  return { metaLength, cursor: next };
+}
+
 function parseMetaEvent(
   data: Uint8Array,
   pos: number,
@@ -69,10 +99,7 @@ function parseMetaEvent(
 
   // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
   const metaType = data[pos]!;
-  let cursor = pos + 1;
-
-  const { value: metaLength, bytesRead: mlBytes } = decodeVlq(data, cursor);
-  cursor += mlBytes;
+  const { metaLength, cursor } = decodeMetaLength(data, pos + 1, end);
 
   if (metaType === 0x2f) {
     // End of track — metaLength must be 0 per SMF spec.

--- a/src/midi-file/decode.ts
+++ b/src/midi-file/decode.ts
@@ -70,20 +70,12 @@ function decodeMetaLength(
   cursor: number,
   end: number,
 ): { readonly metaLength: number; readonly cursor: number } {
-  if (cursor >= end) {
-    throw new RangeError(`Truncated meta event length at offset ${cursor}.`);
-  }
+  // Bound the decode at the track end so a length VLQ whose bytes run past the
+  // track (a missing length byte, or a multi-byte VLQ overrunning the boundary)
+  // throws before reading a byte that belongs to the next chunk.
+  const { value: metaLength, bytesRead } = decodeVlq(data, cursor, end);
 
-  const { value: metaLength, bytesRead } = decodeVlq(data, cursor);
-  const next = cursor + bytesRead;
-
-  if (next > end) {
-    throw new RangeError(
-      `Meta event length field at offset ${cursor} exceeds track boundary ${end}.`,
-    );
-  }
-
-  return { metaLength, cursor: next };
+  return { metaLength, cursor: cursor + bytesRead };
 }
 
 function parseMetaEvent(

--- a/src/midi-file/decode.ts
+++ b/src/midi-file/decode.ts
@@ -1,0 +1,476 @@
+/**
+ * Parses a Standard MIDI File (SMF) byte array and reconstructs a {@link Sequence}.
+ */
+
+import { Note } from '../note.js';
+import { Sequence } from '../sequences/sequence.js';
+import { Meter } from '../meter.js';
+import { createRational } from '../rational.js';
+import type { NoteEvent, MusicEvent } from '../sequences/types.js';
+import { decodeVlq } from './variable-length.js';
+import type { MidiFileDocument, MidiTrackEvent, MidiFileToSequenceOptions } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Header parsing
+// ---------------------------------------------------------------------------
+
+function readUint32(data: Uint8Array, offset: number): number {
+  // Callers must ensure data has at least offset+4 bytes; see length guard in parseMidiFile.
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  return (
+    ((data[offset]! << 24) |
+      (data[offset + 1]! << 16) |
+      (data[offset + 2]! << 8) |
+      data[offset + 3]!) >>>
+    0
+  );
+}
+
+function readUint16(data: Uint8Array, offset: number): number {
+  // Callers must ensure data has at least offset+2 bytes; see length guard in parseMidiFile.
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  return ((data[offset]! << 8) | data[offset + 1]!) >>> 0;
+}
+
+function checkFourCC(data: Uint8Array, offset: number, expected: readonly number[]): boolean {
+  for (let i = 0; i < 4; i++) {
+    if (data[offset + i] !== expected[i]) return false;
+  }
+
+  return true;
+}
+
+const MTHD_BYTES = [0x4d, 0x54, 0x68, 0x64];
+const MTRK_BYTES = [0x4d, 0x54, 0x72, 0x6b];
+
+// ---------------------------------------------------------------------------
+// Meta event parsing (extracted to keep parseTrackEvents under complexity 10)
+// ---------------------------------------------------------------------------
+
+type ParseMetaResult = {
+  /** New position after consuming the meta event data. */
+  readonly pos: number;
+  /** Whether the end-of-track marker was found (caller should break). */
+  readonly done: boolean;
+  /** The parsed event to push. */
+  readonly event: MidiTrackEvent;
+};
+
+function parseMetaEvent(
+  data: Uint8Array,
+  pos: number,
+  end: number,
+  deltaTicks: number,
+): ParseMetaResult {
+  // pos currently points at the byte after 0xFF
+  if (pos >= end) {
+    throw new RangeError(`Truncated meta event at offset ${pos}.`);
+  }
+
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const metaType = data[pos]!;
+  let cursor = pos + 1;
+
+  const { value: metaLength, bytesRead: mlBytes } = decodeVlq(data, cursor);
+  cursor += mlBytes;
+
+  if (metaType === 0x2f) {
+    // End of track — emit the event so the parsed track is a faithful,
+    // exhaustive record of the MidiTrackEvent union.
+    return {
+      pos: cursor + metaLength,
+      done: true,
+      event: { type: 'endOfTrack', deltaTicks },
+    };
+  }
+
+  if (metaType === 0x51 && metaLength === 3) {
+    return parseTempoMeta(data, cursor, metaLength, deltaTicks);
+  }
+
+  if (metaType === 0x58 && metaLength === 4) {
+    return parseTimeSignatureMeta(data, cursor, metaLength, deltaTicks);
+  }
+
+  // Unknown meta
+  const metaData = data.slice(cursor, cursor + metaLength);
+  return {
+    pos: cursor + metaLength,
+    done: false,
+    event: { type: 'unknownMeta', deltaTicks, metaType, data: metaData },
+  };
+}
+
+function parseTempoMeta(
+  data: Uint8Array,
+  pos: number,
+  metaLength: number,
+  deltaTicks: number,
+): ParseMetaResult {
+  const b0 = data[pos];
+  const b1 = data[pos + 1];
+  const b2 = data[pos + 2];
+
+  if (b0 === undefined || b1 === undefined || b2 === undefined) {
+    throw new RangeError(`Truncated tempo meta at offset ${pos}.`);
+  }
+
+  const microsecondsPerQuarter = (b0 << 16) | (b1 << 8) | b2;
+  return {
+    pos: pos + metaLength,
+    done: false,
+    event: { type: 'tempo', deltaTicks, microsecondsPerQuarter },
+  };
+}
+
+function parseTimeSignatureMeta(
+  data: Uint8Array,
+  pos: number,
+  metaLength: number,
+  deltaTicks: number,
+): ParseMetaResult {
+  const b0 = data[pos];
+  const b1 = data[pos + 1];
+  const b2 = data[pos + 2];
+  const b3 = data[pos + 3];
+
+  if (b0 === undefined || b1 === undefined || b2 === undefined || b3 === undefined) {
+    throw new RangeError(`Truncated time signature meta at offset ${pos}.`);
+  }
+
+  return {
+    pos: pos + metaLength,
+    done: false,
+    event: {
+      type: 'timeSignature',
+      deltaTicks,
+      numerator: b0,
+      denominator: Math.pow(2, b1),
+      clocksPerClick: b2,
+      thirtySecondNotesPerQuarter: b3,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Track event parsing
+// ---------------------------------------------------------------------------
+
+function parseTrackEvents(
+  data: Uint8Array,
+  offset: number,
+  length: number,
+): readonly MidiTrackEvent[] {
+  const end = offset + length;
+  const events: MidiTrackEvent[] = [];
+  let pos = offset;
+  let runningStatus = 0;
+
+  while (pos < end) {
+    const { value: deltaTicks, bytesRead } = decodeVlq(data, pos);
+    pos += bytesRead;
+
+    if (pos >= end) {
+      throw new RangeError(`Truncated track data after delta time at offset ${pos}.`);
+    }
+
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const firstByte = data[pos]!;
+
+    if (firstByte === 0xff) {
+      pos++;
+      const result = parseMetaEvent(data, pos, end, deltaTicks);
+      pos = result.pos;
+      runningStatus = 0;
+
+      events.push(result.event);
+
+      if (result.done) break;
+    } else if ((firstByte & 0x80) !== 0) {
+      // Status byte present — update running status
+      runningStatus = firstByte;
+      pos++;
+      pos = parseChannelEvent(data, pos, deltaTicks, runningStatus, events);
+    } else {
+      // No status byte — use running status
+      if (runningStatus === 0) {
+        throw new TypeError(`Running status used before any status byte at offset ${pos}.`);
+      }
+
+      pos = parseChannelEvent(data, pos, deltaTicks, runningStatus, events);
+    }
+  }
+
+  return events;
+}
+
+function parseChannelEvent(
+  data: Uint8Array,
+  pos: number,
+  deltaTicks: number,
+  status: number,
+  events: MidiTrackEvent[],
+): number {
+  const eventType = (status >> 4) & 0x0f;
+  const channel = status & 0x0f;
+
+  const b0 = data[pos];
+  const b1 = data[pos + 1];
+
+  if (b0 === undefined) {
+    throw new RangeError(`Truncated channel event at offset ${pos}.`);
+  }
+
+  if (eventType === 0x09) {
+    // Note-on
+    if (b1 === undefined) {
+      throw new RangeError(`Truncated note-on event at offset ${pos}.`);
+    }
+
+    events.push({ type: 'noteOn', deltaTicks, channel, noteNumber: b0, velocity: b1 });
+
+    return pos + 2;
+  } else if (eventType === 0x08) {
+    // Note-off
+    if (b1 === undefined) {
+      throw new RangeError(`Truncated note-off event at offset ${pos}.`);
+    }
+
+    events.push({ type: 'noteOff', deltaTicks, channel, noteNumber: b0, velocity: b1 });
+
+    return pos + 2;
+  } else {
+    // Other channel events — skip based on event type
+    const dataBytes = channelEventDataLength(eventType);
+    return pos + dataBytes;
+  }
+}
+
+function channelEventDataLength(eventType: number): number {
+  // 4 = program change (1 data byte), 5 = channel pressure (1 data byte)
+  // All other channel events have 2 data bytes.
+  if (eventType === 0x0c || eventType === 0x0d) return 1;
+
+  return 2;
+}
+
+// ---------------------------------------------------------------------------
+// Public: parseMidiFile
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a Standard MIDI File byte array into a structured document.
+ *
+ * @param data The raw SMF bytes.
+ * @returns The parsed MIDI file document.
+ * @throws {TypeError} When the data does not start with a valid MThd header.
+ * @throws {RangeError} When the data is truncated or contains an out-of-range value.
+ */
+export function parseMidiFile(data: Uint8Array): MidiFileDocument {
+  if (data.length < 14) {
+    throw new RangeError(
+      `MIDI file too short: expected at least 14 bytes, received ${data.length}.`,
+    );
+  }
+
+  if (!checkFourCC(data, 0, MTHD_BYTES)) {
+    throw new TypeError(`Invalid MIDI file: expected 'MThd' at offset 0.`);
+  }
+
+  const headerLength = readUint32(data, 4);
+
+  if (headerLength < 6) {
+    throw new RangeError(
+      `Invalid MThd header length: expected at least 6, received ${headerLength}.`,
+    );
+  }
+
+  const rawFormat = readUint16(data, 8);
+
+  if (rawFormat !== 0 && rawFormat !== 1) {
+    throw new TypeError(
+      `Unsupported MIDI file format ${rawFormat}; only format 0 and 1 are supported.`,
+    );
+  }
+
+  // rawFormat is validated to be 0 or 1 by the check above; cast narrows the type.
+  // oxlint-disable-next-line typescript-eslint/no-unnecessary-type-assertion
+  const format = rawFormat as 0 | 1;
+  const ntrks = readUint16(data, 10);
+  const division = readUint16(data, 12);
+
+  if ((division & 0x8000) !== 0) {
+    throw new TypeError(
+      `SMPTE time code division is not supported (high bit set in division field).`,
+    );
+  }
+
+  const tracks: (readonly MidiTrackEvent[])[] = [];
+  let pos = 8 + headerLength;
+
+  for (let t = 0; t < ntrks; t++) {
+    if (pos + 8 > data.length) {
+      throw new RangeError(`Truncated track chunk header at offset ${pos}.`);
+    }
+
+    if (!checkFourCC(data, pos, MTRK_BYTES)) {
+      throw new TypeError(`Expected 'MTrk' at offset ${pos}.`);
+    }
+
+    const trackLength = readUint32(data, pos + 4);
+    pos += 8;
+
+    const trackEvents = parseTrackEvents(data, pos, trackLength);
+    tracks.push(trackEvents);
+    pos += trackLength;
+  }
+
+  return { format, ticksPerQuarter: division, tracks };
+}
+
+// ---------------------------------------------------------------------------
+// Public: midiFileToSequence
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a Standard MIDI File byte array to a {@link Sequence}.
+ *
+ * Uses the last tempo meta event for BPM (multi-tempo files are reduced to
+ * the final value). Uses the last time signature meta event for meter.
+ * Note events are collected by matching note-on and
+ * note-off pairs (treating note-on velocity 0 as note-off).
+ *
+ * @param data The raw SMF bytes.
+ * @param options Optional conversion settings.
+ * @returns The reconstructed sequence.
+ * @throws {TypeError} When the data is not a valid SMF file.
+ * @throws {RangeError} When the data is truncated or contains out-of-range values.
+ */
+export function midiFileToSequence(
+  data: Uint8Array,
+  options?: MidiFileToSequenceOptions,
+): Sequence {
+  const doc = parseMidiFile(data);
+  const defaultTempo = options?.defaultTempo ?? 120;
+
+  let tempoMicros = Math.round(60_000_000 / defaultTempo);
+  let meterNumerator: number | null = null;
+  let meterDenominator: number | null = null;
+
+  const musicEvents: MusicEvent[] = [];
+
+  for (const track of doc.tracks) {
+    processTrack(
+      track,
+      doc.ticksPerQuarter,
+      musicEvents,
+      (micros) => {
+        tempoMicros = micros;
+      },
+      (num, den) => {
+        meterNumerator = num;
+        meterDenominator = den;
+      },
+    );
+  }
+
+  musicEvents.sort((a, b) => {
+    const aVal = a.start.numerator / a.start.denominator;
+    const bVal = b.start.numerator / b.start.denominator;
+    return aVal - bVal;
+  });
+
+  const bpm = Math.round(60_000_000 / tempoMicros);
+
+  let meter: Meter | undefined;
+
+  if (meterNumerator !== null && meterDenominator !== null) {
+    try {
+      meter = Meter.create(meterNumerator, meterDenominator);
+    } catch {
+      // If meter construction fails (e.g. non-power-of-2 denominator), omit it
+    }
+  }
+
+  const sequenceOptions = meter !== undefined ? { tempo: bpm, meter } : { tempo: bpm };
+
+  return Sequence.create(musicEvents, sequenceOptions);
+}
+
+type ActiveNoteMap = Map<number, { readonly onTick: number; readonly velocity: number }>;
+
+function isNoteOff(event: MidiTrackEvent): boolean {
+  if (event.type === 'noteOff') return true;
+  if (event.type === 'noteOn' && event.velocity === 0) return true;
+  return false;
+}
+
+function resolveNoteOff(
+  event: MidiTrackEvent,
+  absoluteTick: number,
+  activeNotes: ActiveNoteMap,
+  ticksPerQuarter: number,
+  musicEvents: MusicEvent[],
+): void {
+  if (event.type !== 'noteOn' && event.type !== 'noteOff') return;
+  const active = activeNotes.get(event.noteNumber);
+
+  if (active !== undefined) {
+    activeNotes.delete(event.noteNumber);
+    const noteEvent = buildNoteEvent(
+      event.noteNumber,
+      active.onTick,
+      absoluteTick,
+      active.velocity,
+      ticksPerQuarter,
+    );
+    if (noteEvent !== null) musicEvents.push(noteEvent);
+  }
+}
+
+function processTrack(
+  track: readonly MidiTrackEvent[],
+  ticksPerQuarter: number,
+  musicEvents: MusicEvent[],
+  onTempo: (micros: number) => void,
+  onMeter: (numerator: number, denominator: number) => void,
+): void {
+  let absoluteTick = 0;
+  const activeNotes: ActiveNoteMap = new Map();
+
+  for (const event of track) {
+    absoluteTick += event.deltaTicks;
+
+    if (event.type === 'tempo') {
+      onTempo(event.microsecondsPerQuarter);
+    } else if (event.type === 'timeSignature') {
+      onMeter(event.numerator, event.denominator);
+    } else if (event.type === 'noteOn' && event.velocity > 0) {
+      activeNotes.set(event.noteNumber, { onTick: absoluteTick, velocity: event.velocity });
+    } else if (isNoteOff(event)) {
+      resolveNoteOff(event, absoluteTick, activeNotes, ticksPerQuarter, musicEvents);
+    }
+  }
+}
+
+function buildNoteEvent(
+  noteNumber: number,
+  onTick: number,
+  offTick: number,
+  velocity: number,
+  ticksPerQuarter: number,
+): NoteEvent | null {
+  if (offTick <= onTick) return null;
+
+  // Convert ticks to whole-note fractions.
+  // 1 whole note = 4 quarters = 4 * ticksPerQuarter ticks
+  const wholeTicks = 4 * ticksPerQuarter;
+  const start = createRational(onTick, wholeTicks);
+  const duration = createRational(offTick - onTick, wholeTicks);
+
+  // MIDI note bytes are 0–127; Note.fromMidi accepts that full range.
+  const note = Note.fromMidi(noteNumber);
+
+  // velocity is always 1–127: callers only store note-on events where velocity > 0.
+  return { type: 'note', note, start, duration, velocity };
+}

--- a/src/midi-file/decode.ts
+++ b/src/midi-file/decode.ts
@@ -75,13 +75,22 @@ function parseMetaEvent(
   cursor += mlBytes;
 
   if (metaType === 0x2f) {
-    // End of track — emit the event so the parsed track is a faithful,
-    // exhaustive record of the MidiTrackEvent union.
+    // End of track — metaLength must be 0 per SMF spec.
+    if (metaLength !== 0) {
+      throw new RangeError(`End-of-track meta event must have length 0, received ${metaLength}.`);
+    }
     return {
-      pos: cursor + metaLength,
+      pos: cursor,
       done: true,
       event: { type: 'endOfTrack', deltaTicks },
     };
+  }
+
+  // Bounds check: the declared payload must fit within the track boundary.
+  if (cursor + metaLength > end) {
+    throw new RangeError(
+      `Meta event payload (length ${metaLength}) at offset ${cursor} exceeds track boundary ${end}.`,
+    );
   }
 
   if (metaType === 0x51 && metaLength === 3) {
@@ -107,13 +116,12 @@ function parseTempoMeta(
   metaLength: number,
   deltaTicks: number,
 ): ParseMetaResult {
-  const b0 = data[pos];
-  const b1 = data[pos + 1];
-  const b2 = data[pos + 2];
-
-  if (b0 === undefined || b1 === undefined || b2 === undefined) {
-    throw new RangeError(`Truncated tempo meta at offset ${pos}.`);
-  }
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const b0 = data[pos]!;
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const b1 = data[pos + 1]!;
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const b2 = data[pos + 2]!;
 
   const microsecondsPerQuarter = (b0 << 16) | (b1 << 8) | b2;
   return {
@@ -129,14 +137,14 @@ function parseTimeSignatureMeta(
   metaLength: number,
   deltaTicks: number,
 ): ParseMetaResult {
-  const b0 = data[pos];
-  const b1 = data[pos + 1];
-  const b2 = data[pos + 2];
-  const b3 = data[pos + 3];
-
-  if (b0 === undefined || b1 === undefined || b2 === undefined || b3 === undefined) {
-    throw new RangeError(`Truncated time signature meta at offset ${pos}.`);
-  }
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const b0 = data[pos]!;
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const b1 = data[pos + 1]!;
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const b2 = data[pos + 2]!;
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const b3 = data[pos + 3]!;
 
   return {
     pos: pos + metaLength,
@@ -190,23 +198,32 @@ function parseTrackEvents(
       // Status byte present — update running status
       runningStatus = firstByte;
       pos++;
-      pos = parseChannelEvent(data, pos, deltaTicks, runningStatus, events);
+      pos = parseChannelEvent(data, pos, end, deltaTicks, runningStatus, events);
     } else {
       // No status byte — use running status
       if (runningStatus === 0) {
         throw new TypeError(`Running status used before any status byte at offset ${pos}.`);
       }
 
-      pos = parseChannelEvent(data, pos, deltaTicks, runningStatus, events);
+      pos = parseChannelEvent(data, pos, end, deltaTicks, runningStatus, events);
     }
   }
 
   return events;
 }
 
+function validateDataByte(value: number, offset: number): void {
+  if (value > 0x7f) {
+    throw new RangeError(
+      `Invalid MIDI data byte 0x${value.toString(16).toUpperCase()} at offset ${offset}; data bytes must be 0..127.`,
+    );
+  }
+}
+
 function parseChannelEvent(
   data: Uint8Array,
   pos: number,
+  end: number,
   deltaTicks: number,
   status: number,
   events: MidiTrackEvent[],
@@ -214,35 +231,37 @@ function parseChannelEvent(
   const eventType = (status >> 4) & 0x0f;
   const channel = status & 0x0f;
 
-  const b0 = data[pos];
-  const b1 = data[pos + 1];
+  const needed = channelEventDataLength(eventType);
 
-  if (b0 === undefined) {
+  if (pos + needed > end) {
     throw new RangeError(`Truncated channel event at offset ${pos}.`);
   }
 
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const b0 = data[pos]!;
+  validateDataByte(b0, pos);
+
   if (eventType === 0x09) {
     // Note-on
-    if (b1 === undefined) {
-      throw new RangeError(`Truncated note-on event at offset ${pos}.`);
-    }
-
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const b1 = data[pos + 1]!;
+    validateDataByte(b1, pos + 1);
     events.push({ type: 'noteOn', deltaTicks, channel, noteNumber: b0, velocity: b1 });
-
     return pos + 2;
   } else if (eventType === 0x08) {
     // Note-off
-    if (b1 === undefined) {
-      throw new RangeError(`Truncated note-off event at offset ${pos}.`);
-    }
-
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const b1 = data[pos + 1]!;
+    validateDataByte(b1, pos + 1);
     events.push({ type: 'noteOff', deltaTicks, channel, noteNumber: b0, velocity: b1 });
-
     return pos + 2;
   } else {
-    // Other channel events — skip based on event type
-    const dataBytes = channelEventDataLength(eventType);
-    return pos + dataBytes;
+    // Other channel events — skip, validating all data bytes
+    for (let i = 1; i < needed; i++) {
+      // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+      validateDataByte(data[pos + i]!, pos + i);
+    }
+    return pos + needed;
   }
 }
 
@@ -252,6 +271,43 @@ function channelEventDataLength(eventType: number): number {
   if (eventType === 0x0c || eventType === 0x0d) return 1;
 
   return 2;
+}
+
+// ---------------------------------------------------------------------------
+// Track chunk loop (extracted to keep parseMidiFile under complexity 10)
+// ---------------------------------------------------------------------------
+
+function parseTracks(
+  data: Uint8Array,
+  ntrks: number,
+  startPos: number,
+): { readonly tracks: (readonly MidiTrackEvent[])[]; readonly pos: number } {
+  const tracks: (readonly MidiTrackEvent[])[] = [];
+  let pos = startPos;
+
+  for (let t = 0; t < ntrks; t++) {
+    if (pos + 8 > data.length) {
+      throw new RangeError(`Truncated track chunk header at offset ${pos}.`);
+    }
+
+    if (!checkFourCC(data, pos, MTRK_BYTES)) {
+      throw new TypeError(`Expected 'MTrk' at offset ${pos}.`);
+    }
+
+    const trackLength = readUint32(data, pos + 4);
+    pos += 8;
+
+    if (pos + trackLength > data.length) {
+      throw new RangeError(
+        `Track ${t} declares length ${trackLength} at offset ${pos} but file only has ${data.length - pos} bytes remaining.`,
+      );
+    }
+
+    tracks.push(parseTrackEvents(data, pos, trackLength));
+    pos += trackLength;
+  }
+
+  return { tracks, pos };
 }
 
 // ---------------------------------------------------------------------------
@@ -305,25 +361,7 @@ export function parseMidiFile(data: Uint8Array): MidiFileDocument {
     );
   }
 
-  const tracks: (readonly MidiTrackEvent[])[] = [];
-  let pos = 8 + headerLength;
-
-  for (let t = 0; t < ntrks; t++) {
-    if (pos + 8 > data.length) {
-      throw new RangeError(`Truncated track chunk header at offset ${pos}.`);
-    }
-
-    if (!checkFourCC(data, pos, MTRK_BYTES)) {
-      throw new TypeError(`Expected 'MTrk' at offset ${pos}.`);
-    }
-
-    const trackLength = readUint32(data, pos + 4);
-    pos += 8;
-
-    const trackEvents = parseTrackEvents(data, pos, trackLength);
-    tracks.push(trackEvents);
-    pos += trackLength;
-  }
+  const { tracks, pos: _finalPos } = parseTracks(data, ntrks, 8 + headerLength);
 
   return { format, ticksPerQuarter: division, tracks };
 }
@@ -397,7 +435,20 @@ export function midiFileToSequence(
   return Sequence.create(musicEvents, sequenceOptions);
 }
 
-type ActiveNoteMap = Map<number, { readonly onTick: number; readonly velocity: number }>;
+/**
+ * Key for the active-note map: channel * 128 + noteNumber.
+ * This uniquely identifies a pitch-on-channel combination since noteNumber ≤ 127.
+ */
+function activeNoteKey(channel: number, noteNumber: number): number {
+  return channel * 128 + noteNumber;
+}
+
+/**
+ * FIFO queue of pending note-on onsets for a single (channel, noteNumber) key.
+ * note-on pushes; note-off pops the oldest onset so overlapping notes pair correctly.
+ */
+type ActiveNoteQueue = Array<{ readonly onTick: number; readonly velocity: number }>;
+type ActiveNoteMap = Map<number, ActiveNoteQueue>;
 
 function isNoteOff(event: MidiTrackEvent): boolean {
   if (event.type === 'noteOff') return true;
@@ -413,10 +464,13 @@ function resolveNoteOff(
   musicEvents: MusicEvent[],
 ): void {
   if (event.type !== 'noteOn' && event.type !== 'noteOff') return;
-  const active = activeNotes.get(event.noteNumber);
+  const key = activeNoteKey(event.channel, event.noteNumber);
+  const queue = activeNotes.get(key);
 
-  if (active !== undefined) {
-    activeNotes.delete(event.noteNumber);
+  if (queue !== undefined && queue.length > 0) {
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const active = queue.shift()!;
+    if (queue.length === 0) activeNotes.delete(key);
     const noteEvent = buildNoteEvent(
       event.noteNumber,
       active.onTick,
@@ -446,7 +500,13 @@ function processTrack(
     } else if (event.type === 'timeSignature') {
       onMeter(event.numerator, event.denominator);
     } else if (event.type === 'noteOn' && event.velocity > 0) {
-      activeNotes.set(event.noteNumber, { onTick: absoluteTick, velocity: event.velocity });
+      const key = activeNoteKey(event.channel, event.noteNumber);
+      const queue = activeNotes.get(key);
+      if (queue !== undefined) {
+        queue.push({ onTick: absoluteTick, velocity: event.velocity });
+      } else {
+        activeNotes.set(key, [{ onTick: absoluteTick, velocity: event.velocity }]);
+      }
     } else if (isNoteOff(event)) {
       resolveNoteOff(event, absoluteTick, activeNotes, ticksPerQuarter, musicEvents);
     }

--- a/src/midi-file/decode.ts
+++ b/src/midi-file/decode.ts
@@ -194,7 +194,7 @@ function parseTrackEvents(
   let runningStatus = 0;
 
   while (pos < end) {
-    const { value: deltaTicks, bytesRead } = decodeVlq(data, pos);
+    const { value: deltaTicks, bytesRead } = decodeVlq(data, pos, end);
     pos += bytesRead;
 
     if (pos >= end) {
@@ -213,6 +213,12 @@ function parseTrackEvents(
       events.push(result.event);
 
       if (result.done) break;
+    } else if (firstByte >= 0xf0) {
+      // SysEx (0xF0, 0xF7) and other system messages are not supported.
+      // Silently mis-parsing them as channel events would desync the parser.
+      throw new TypeError(
+        `Unsupported system status byte 0x${firstByte.toString(16).toUpperCase()} at offset ${pos}; SysEx and system messages are not supported.`,
+      );
     } else if ((firstByte & 0x80) !== 0) {
       // Status byte present — update running status
       runningStatus = firstByte;

--- a/src/midi-file/encode.ts
+++ b/src/midi-file/encode.ts
@@ -1,0 +1,273 @@
+/**
+ * Encodes a {@link Sequence} to a Standard MIDI File (SMF) byte array.
+ */
+
+import type { Sequence } from '../sequences/sequence.js';
+import type { MusicEvent, NoteEvent, ChordEvent } from '../sequences/types.js';
+import { encodeVlq } from './variable-length.js';
+import type { SequenceToMidiOptions } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TICKS_PER_QUARTER = 480;
+const DEFAULT_CHANNEL = 0;
+const DEFAULT_VELOCITY = 64;
+
+/** MThd chunk ID bytes */
+const MTHD = [0x4d, 0x54, 0x68, 0x64];
+/** MTrk chunk ID bytes */
+const MTRK = [0x4d, 0x54, 0x72, 0x6b];
+
+// ---------------------------------------------------------------------------
+// Low-level byte helpers
+// ---------------------------------------------------------------------------
+
+function writeUint32(value: number): readonly number[] {
+  return [(value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff];
+}
+
+function writeUint16(value: number): readonly number[] {
+  return [(value >>> 8) & 0xff, value & 0xff];
+}
+
+// ---------------------------------------------------------------------------
+// Time conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a whole-note fraction to integer ticks.
+ *
+ * A whole note = 4 quarter notes, and division is ticks per quarter.
+ * ticks = fraction * 4 * division, rounded to nearest integer.
+ */
+function rationalToTicks(numerator: number, denominator: number, division: number): number {
+  return Math.round((numerator / denominator) * 4 * division);
+}
+
+// ---------------------------------------------------------------------------
+// Meta event builders
+// ---------------------------------------------------------------------------
+
+function buildTempoEvent(deltaTicks: number, bpm: number): readonly number[] {
+  const us = Math.round(60_000_000 / bpm);
+  return [
+    ...encodeVlq(deltaTicks),
+    0xff,
+    0x51,
+    0x03,
+    (us >>> 16) & 0xff,
+    (us >>> 8) & 0xff,
+    us & 0xff,
+  ];
+}
+
+function buildTimeSignatureEvent(
+  deltaTicks: number,
+  numerator: number,
+  denominator: number,
+): readonly number[] {
+  // dd is the power-of-2 exponent of the denominator (e.g. 4 -> 2, 8 -> 3)
+  const dd = Math.round(Math.log2(denominator));
+  return [
+    ...encodeVlq(deltaTicks),
+    0xff,
+    0x58,
+    0x04,
+    numerator,
+    dd,
+    0x18, // 24 MIDI clocks per metronome click (standard)
+    0x08, // 8 thirty-second notes per MIDI quarter (standard)
+  ];
+}
+
+function buildEndOfTrackEvent(deltaTicks: number): readonly number[] {
+  return [...encodeVlq(deltaTicks), 0xff, 0x2f, 0x00];
+}
+
+// ---------------------------------------------------------------------------
+// Note event pair collection
+// ---------------------------------------------------------------------------
+
+type NoteEventPair = {
+  readonly onTick: number;
+  readonly offTick: number;
+  readonly noteNumber: number;
+  readonly velocity: number;
+};
+
+function collectNoteEventPairs(event: NoteEvent, division: number): readonly NoteEventPair[] {
+  const onTick = rationalToTicks(event.start.numerator, event.start.denominator, division);
+  const durationTicks = rationalToTicks(
+    event.duration.numerator,
+    event.duration.denominator,
+    division,
+  );
+  const offTick = onTick + durationTicks;
+  const noteNumber = event.note.midi as number;
+  const velocity = event.velocity ?? DEFAULT_VELOCITY;
+
+  return [{ onTick, offTick, noteNumber, velocity }];
+}
+
+function collectChordNoteEventPairs(event: ChordEvent, division: number): readonly NoteEventPair[] {
+  const onTick = rationalToTicks(event.start.numerator, event.start.denominator, division);
+  const durationTicks = rationalToTicks(
+    event.duration.numerator,
+    event.duration.denominator,
+    division,
+  );
+  const offTick = onTick + durationTicks;
+  const velocity = event.velocity ?? DEFAULT_VELOCITY;
+
+  return event.chord.notes.map((note) => ({
+    onTick,
+    offTick,
+    noteNumber: note.midi as number,
+    velocity,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Track bytes builder
+// ---------------------------------------------------------------------------
+
+type TickEvent = {
+  readonly tick: number;
+  readonly isNoteOn: boolean;
+  readonly noteNumber: number;
+  readonly velocity: number;
+};
+
+function buildTickEvents(events: readonly MusicEvent[], division: number): readonly TickEvent[] {
+  const tickEvents: TickEvent[] = [];
+
+  for (const event of events) {
+    let pairs: readonly NoteEventPair[];
+
+    if (event.type === 'note') {
+      pairs = collectNoteEventPairs(event, division);
+    } else if (event.type === 'chord') {
+      pairs = collectChordNoteEventPairs(event, division);
+    } else {
+      // rest — no MIDI events
+      continue;
+    }
+
+    for (const pair of pairs) {
+      tickEvents.push({
+        tick: pair.onTick,
+        isNoteOn: true,
+        noteNumber: pair.noteNumber,
+        velocity: pair.velocity,
+      });
+      // Use note-on with velocity 0 for note-off (consistent with spec note #31)
+      tickEvents.push({
+        tick: pair.offTick,
+        isNoteOn: false,
+        noteNumber: pair.noteNumber,
+        velocity: 0,
+      });
+    }
+  }
+
+  // Sort by tick; note-offs before note-ons at same tick for clean output
+  tickEvents.sort((a, b) => {
+    if (a.tick !== b.tick) return a.tick - b.tick;
+    if (!a.isNoteOn && b.isNoteOn) return -1;
+    if (a.isNoteOn && !b.isNoteOn) return 1;
+    return a.noteNumber - b.noteNumber;
+  });
+
+  return tickEvents;
+}
+
+function buildTrackBytes(
+  events: readonly MusicEvent[],
+  tempo: number,
+  meter: { readonly numerator: number; readonly denominator: number } | null,
+  division: number,
+  channel: number,
+): readonly number[] {
+  const bytes: number[] = [];
+
+  // Tempo meta at tick 0
+  bytes.push(...buildTempoEvent(0, tempo));
+
+  // Time signature meta at tick 0
+  if (meter !== null) {
+    bytes.push(...buildTimeSignatureEvent(0, meter.numerator, meter.denominator));
+  } else {
+    bytes.push(...buildTimeSignatureEvent(0, 4, 4));
+  }
+
+  const tickEvents = buildTickEvents(events, division);
+  let currentTick = 0;
+
+  for (const te of tickEvents) {
+    const delta = te.tick - currentTick;
+    currentTick = te.tick;
+    // Always use 0x90 | ch: note-off is note-on with velocity 0 per SMF spec note #31
+    const statusByte = 0x90 | (channel & 0x0f);
+    bytes.push(...encodeVlq(delta), statusByte, te.noteNumber, te.velocity);
+  }
+
+  // End of track
+  bytes.push(...buildEndOfTrackEvent(0));
+
+  return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Serializes an octavian {@link Sequence} to a valid Standard MIDI File byte array.
+ *
+ * Produces a Type 0 SMF (single track) with:
+ * - A tempo meta event (FF 51 03 ...) derived from `sequence.tempo`
+ * - A time signature meta event (FF 58 04 ...) derived from `sequence.meter` (defaults to 4/4)
+ * - Note-on/off pairs for every note and chord event (note-off encoded as note-on with velocity 0)
+ * - End-of-track marker (FF 2F 00)
+ *
+ * @param sequence The sequence to serialize.
+ * @param options Optional serialization settings.
+ * @returns The SMF bytes.
+ */
+export function sequenceToMidiFile(
+  sequence: Sequence,
+  options?: SequenceToMidiOptions,
+): Uint8Array {
+  const division = options?.ticksPerQuarter ?? DEFAULT_TICKS_PER_QUARTER;
+  const channel = options?.channel ?? DEFAULT_CHANNEL;
+
+  const meter =
+    sequence.meter !== null
+      ? { numerator: sequence.meter.numerator, denominator: sequence.meter.denominator }
+      : null;
+
+  const trackBytes = buildTrackBytes(sequence.events, sequence.tempo, meter, division, channel);
+
+  const output: number[] = [
+    // MThd
+    ...MTHD,
+    // header length = 6
+    ...writeUint32(6),
+    // format = 0
+    ...writeUint16(0),
+    // ntrks = 1
+    ...writeUint16(1),
+    // division (ticks per quarter, high bit 0)
+    ...writeUint16(division),
+    // MTrk
+    ...MTRK,
+    // track byte length
+    ...writeUint32(trackBytes.length),
+    // track data
+    ...trackBytes,
+  ];
+
+  return new Uint8Array(output);
+}

--- a/src/midi-file/encode.ts
+++ b/src/midi-file/encode.ts
@@ -50,8 +50,20 @@ function rationalToTicks(numerator: number, denominator: number, division: numbe
 // Meta event builders
 // ---------------------------------------------------------------------------
 
-function buildTempoEvent(deltaTicks: number, bpm: number): readonly number[] {
+function validateTempoForEncoding(bpm: number): number {
+  // bpm is sourced from sequence.tempo which Sequence.create validates as finite-positive.
+  // Guard the SMF encoding range: microseconds per quarter must fit in a 24-bit field.
   const us = Math.round(60_000_000 / bpm);
+  if (us < 1 || us > 0xffffff) {
+    throw new RangeError(
+      `Tempo ${bpm} BPM yields ${us} microseconds per quarter, which is outside the valid SMF range 1..16777215.`,
+    );
+  }
+  return us;
+}
+
+function buildTempoEvent(deltaTicks: number, bpm: number): readonly number[] {
+  const us = validateTempoForEncoding(bpm);
   return [
     ...encodeVlq(deltaTicks),
     0xff,
@@ -105,7 +117,7 @@ function collectNoteEventPairs(event: NoteEvent, division: number): readonly Not
     division,
   );
   const offTick = onTick + durationTicks;
-  const noteNumber = event.note.midi as number;
+  const noteNumber = Number(event.note.midi);
   const velocity = event.velocity ?? DEFAULT_VELOCITY;
 
   return [{ onTick, offTick, noteNumber, velocity }];
@@ -124,7 +136,7 @@ function collectChordNoteEventPairs(event: ChordEvent, division: number): readon
   return event.chord.notes.map((note) => ({
     onTick,
     offTick,
-    noteNumber: note.midi as number,
+    noteNumber: Number(note.midi),
     velocity,
   }));
 }
@@ -223,6 +235,29 @@ function buildTrackBytes(
 // Public API
 // ---------------------------------------------------------------------------
 
+function validateDivision(division: number): void {
+  if (!Number.isInteger(division) || division < 1 || division > 0x7fff) {
+    throw new RangeError(`ticksPerQuarter must be an integer in 1..32767, received ${division}.`);
+  }
+}
+
+function validateChannel(channel: number): void {
+  if (!Number.isInteger(channel) || channel < 0 || channel > 15) {
+    throw new RangeError(`channel must be an integer in 0..15, received ${channel}.`);
+  }
+}
+
+function validateOptions(options: SequenceToMidiOptions | undefined): {
+  readonly division: number;
+  readonly channel: number;
+} {
+  const division = options?.ticksPerQuarter ?? DEFAULT_TICKS_PER_QUARTER;
+  const channel = options?.channel ?? DEFAULT_CHANNEL;
+  validateDivision(division);
+  validateChannel(channel);
+  return { division, channel };
+}
+
 /**
  * Serializes an octavian {@link Sequence} to a valid Standard MIDI File byte array.
  *
@@ -240,8 +275,7 @@ export function sequenceToMidiFile(
   sequence: Sequence,
   options?: SequenceToMidiOptions,
 ): Uint8Array {
-  const division = options?.ticksPerQuarter ?? DEFAULT_TICKS_PER_QUARTER;
-  const channel = options?.channel ?? DEFAULT_CHANNEL;
+  const { division, channel } = validateOptions(options);
 
   const meter =
     sequence.meter !== null

--- a/src/midi-file/encode.ts
+++ b/src/midi-file/encode.ts
@@ -116,6 +116,14 @@ type NoteEventPair = {
   readonly velocity: number;
 };
 
+function validateEventVelocity(velocity: number): void {
+  if (velocity === 0) {
+    throw new RangeError(
+      `Note event velocity must be 1..127 for MIDI conversion (0 is interpreted as note-off), received 0.`,
+    );
+  }
+}
+
 function collectNoteEventPairs(event: NoteEvent, division: number): readonly NoteEventPair[] {
   const onTick = rationalToTicks(event.start.numerator, event.start.denominator, division);
   const durationTicks = rationalToTicks(
@@ -126,6 +134,7 @@ function collectNoteEventPairs(event: NoteEvent, division: number): readonly Not
   const offTick = onTick + durationTicks;
   const noteNumber = Number(event.note.midi);
   const velocity = event.velocity ?? DEFAULT_VELOCITY;
+  validateEventVelocity(velocity);
 
   return [{ onTick, offTick, noteNumber, velocity }];
 }
@@ -139,6 +148,7 @@ function collectChordNoteEventPairs(event: ChordEvent, division: number): readon
   );
   const offTick = onTick + durationTicks;
   const velocity = event.velocity ?? DEFAULT_VELOCITY;
+  validateEventVelocity(velocity);
 
   return event.chord.notes.map((note) => ({
     onTick,

--- a/src/midi-file/encode.ts
+++ b/src/midi-file/encode.ts
@@ -51,7 +51,14 @@ function rationalToTicks(numerator: number, denominator: number, division: numbe
 // ---------------------------------------------------------------------------
 
 function validateTempoForEncoding(bpm: number): number {
-  // bpm is sourced from sequence.tempo which Sequence.create validates as finite-positive.
+  // bpm normally comes from sequence.tempo, but Sequence's constructor is
+  // protected — a subclass could supply a non-finite tempo, and `NaN` slips
+  // through the range check below (NaN comparisons are always false). Reject it
+  // explicitly so we never emit nonsense (00 00 00) tempo bytes.
+  if (!Number.isFinite(bpm) || bpm <= 0) {
+    throw new RangeError(`Tempo must be a finite positive number, received ${bpm}.`);
+  }
+
   // Guard the SMF encoding range: microseconds per quarter must fit in a 24-bit field.
   const us = Math.round(60_000_000 / bpm);
   if (us < 1 || us > 0xffffff) {

--- a/src/midi-file/index.ts
+++ b/src/midi-file/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Standard MIDI File (SMF) serialization and parsing for octavian sequences.
+ *
+ * Import as `octavian/midi-file` (this is a subpath export, not part of the
+ * root barrel at `octavian`). The root `src/index.ts` MUST NOT re-export from
+ * this module. Public surface: `sequenceToMidiFile`, `parseMidiFile`, and
+ * `midiFileToSequence`.
+ */
+
+export { sequenceToMidiFile } from './encode.js';
+export { parseMidiFile, midiFileToSequence } from './decode.js';
+
+export type {
+  MidiNoteOnEvent,
+  MidiNoteOffEvent,
+  MidiTempoEvent,
+  MidiTimeSignatureEvent,
+  MidiEndOfTrackEvent,
+  MidiUnknownMetaEvent,
+  MidiTrackEvent,
+  MidiFileDocument,
+  SequenceToMidiOptions,
+  MidiFileToSequenceOptions,
+} from './types.js';

--- a/src/midi-file/midi-file-decode.test.ts
+++ b/src/midi-file/midi-file-decode.test.ts
@@ -358,6 +358,35 @@ describe('parseMidiFile — track event parsing', () => {
     expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
   });
 
+  it('throws RangeError (Truncated VLQ) when delta-time VLQ at track boundary is a lone continuation byte', () => {
+    // Track has exactly 1 byte: 0x81 (continuation byte, high bit set).
+    // A trailing file byte (0x00) sits at track end + 1 — the parser must NOT
+    // read it.  Without the `end` limit fix, decodeVlq consumes the trailing
+    // byte and returns successfully; with the fix it throws "Truncated VLQ".
+    // prettier-ignore
+    const truncated = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, 0x01,                          // track length = 1 (one byte only)
+      0x81,                                            // lone continuation byte at track boundary
+      0x00,                                            // trailing file byte, outside the track
+    ]);
+    expect(() => parseMidiFile(truncated)).toThrow(/Truncated VLQ/);
+  });
+
+  it('throws TypeError for a 0xF0 SysEx status byte', () => {
+    // 0xF0 is a SysEx start byte — unsupported; must throw TypeError before trying
+    // to parse it as a channel event (which would desync the parser).
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xf0, 0x03, 0x41, 0x10, 0xf7, // SysEx: delta=0, F0, len=3, payload, F7
+      0x00, 0xff, 0x2f, 0x00,              // end of track
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(TypeError);
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(/0xF0/);
+  });
+
   it('throws RangeError when a channel data byte is >= 0x80 (status-like, malformed stream)', () => {
     // Note-on C4 with velocity 0x80 — velocity byte >= 0x80 is invalid per SMF spec.
     // prettier-ignore

--- a/src/midi-file/midi-file-decode.test.ts
+++ b/src/midi-file/midi-file-decode.test.ts
@@ -250,6 +250,38 @@ describe('parseMidiFile — track event parsing', () => {
     expect(() => parseMidiFile(truncated)).toThrow(RangeError);
   });
 
+  it('throws RangeError when a meta event length byte lies outside the track (FF 2F with a trailing file byte)', () => {
+    // Track declares 3 bytes: delta(00) FF 2F — the length byte is missing from
+    // the track. A trailing file byte (00) sits just past the track end; the
+    // parser must NOT borrow it to satisfy the end-of-track length VLQ.
+    // prettier-ignore
+    const truncated = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, 0x03,                          // track length = 3
+      0x00, 0xff, 0x2f,                                // delta + FF 2F, length byte missing
+      0x00,                                            // trailing file byte, outside the track
+    ]);
+    expect(() => parseMidiFile(truncated)).toThrow(RangeError);
+  });
+
+  it('throws RangeError when a multi-byte meta length VLQ extends past the track boundary', () => {
+    // Track declares 4 bytes: delta(00) FF 01(type) 81(VLQ continuation byte).
+    // The length VLQ starts inside the track but its second byte falls on the
+    // trailing file byte (00), outside the track — the parser must reject it.
+    // prettier-ignore
+    const truncated = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, 0x04,                          // track length = 4
+      0x00, 0xff, 0x01, 0x81,                          // delta + FF 01 + VLQ start (needs a 2nd byte)
+      0x00,                                            // trailing file byte, outside the track
+    ]);
+    expect(() => parseMidiFile(truncated)).toThrow(RangeError);
+  });
+
   it('throws RangeError on truncated tempo meta', () => {
     // prettier-ignore
     const trackData = [
@@ -549,5 +581,17 @@ describe('sequenceToMidiFile — option validation', () => {
   it('throws RangeError when tempo yields microseconds exceeding 0xffffff (very slow BPM)', () => {
     const slowSeq = Sequence.create([], { tempo: 0.001 });
     expect(() => sequenceToMidiFile(slowSeq)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for a non-finite tempo (NaN) supplied via a subclass', () => {
+    // Sequence.create validates tempo, but the constructor is protected, so a
+    // subclass can inject a non-finite tempo. NaN slips through the SMF range
+    // check (NaN comparisons are always false) and must be rejected explicitly.
+    class NaNTempoSequence extends Sequence {
+      constructor() {
+        super([], NaN, null);
+      }
+    }
+    expect(() => sequenceToMidiFile(new NaNTempoSequence())).toThrow(RangeError);
   });
 });

--- a/src/midi-file/midi-file-decode.test.ts
+++ b/src/midi-file/midi-file-decode.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect } from 'bun:test';
+import { Note } from '../note.js';
+import { Sequence, musicalTime } from '../sequences/sequence.js';
+import { sequenceToMidiFile } from './encode.js';
+import { parseMidiFile, midiFileToSequence } from './decode.js';
+
+// ---------------------------------------------------------------------------
+// Helper shared by several tests in this file
+// ---------------------------------------------------------------------------
+
+function buildSimpleMidi(trackData: number[]): Uint8Array {
+  // prettier-ignore
+  return new Uint8Array([
+    0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd chunk header
+    0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,               // format=0, tracks=1, division=480
+    0x4d, 0x54, 0x72, 0x6b,                           // MTrk chunk header
+    0x00, 0x00, 0x00, trackData.length,               // track length
+    ...trackData,
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// midiFileToSequence edge cases
+// ---------------------------------------------------------------------------
+
+describe('midiFileToSequence — edge cases', () => {
+  it('ignores unknown meta events (does not crash, isNoteOff returns false for them)', () => {
+    // Track contains an unknown meta event (type 0x07) followed by end-of-track.
+    // This exercises the isNoteOff(unknownMeta) → false path in processTrack.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xff, 0x07, 0x03, 0x61, 0x62, 0x63, // unknown meta
+      0x00, 0xff, 0x2f, 0x00,                    // end of track
+    ];
+    const bytes = buildSimpleMidi(trackData);
+    const result = midiFileToSequence(bytes);
+    expect(result.events.length).toBe(0);
+  });
+
+  it('uses defaultTempo when no tempo meta event is present in the file', () => {
+    // Build a minimal MIDI file with only end-of-track — no tempo meta.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xff, 0x2f, 0x00, // delta=0, end of track
+    ];
+    // prettier-ignore
+    const bytes = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, trackData.length,              // track length
+      ...trackData,
+    ]);
+    const result = midiFileToSequence(bytes, { defaultTempo: 100 });
+    expect(result.tempo).toBe(100);
+  });
+
+  it('handles running status parsing (end-of-track only track)', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xff, 0x2f, 0x00, // delta=0, end of track
+    ];
+    // prettier-ignore
+    const bytes = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, 0x04,                          // track length = 4
+      ...trackData,
+    ]);
+    const result = midiFileToSequence(bytes);
+    expect(result.events.length).toBe(0);
+    expect(result.tempo).toBe(120);
+  });
+
+  it('handles running status with actual repeated note-on events', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x90, 0x3c, 0x40, // note-on C4 vel 64
+      0x78, 0x3c, 0x00,       // delta=120, running status, C4, vel 0 = note-off
+      0x00, 0xff, 0x2f, 0x00, // end of track
+    ];
+    // prettier-ignore
+    const bytes = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, trackData.length,              // track length
+      ...trackData,
+    ]);
+    const result = midiFileToSequence(bytes);
+    expect(result.events.length).toBe(1);
+    expect(result.events[0]?.type).toBe('note');
+    if (result.events[0]?.type === 'note') {
+      expect(result.events[0].note.midi).toBe(60); // C4
+    }
+  });
+
+  it('ignores note-off events with no matching note-on', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x80, 0x3c, 0x00, // note-off C4 with no prior note-on
+      0x00, 0xff, 0x2f, 0x00, // end of track
+    ];
+    // prettier-ignore
+    const bytes = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, trackData.length,              // track length
+      ...trackData,
+    ]);
+    const result = midiFileToSequence(bytes);
+    expect(result.events.length).toBe(0);
+  });
+
+  it('skips note events where off <= on (zero duration)', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x90, 0x3c, 0x40, // note-on C4 at tick 0
+      0x00, 0x80, 0x3c, 0x00, // note-off C4 at tick 0 (same tick)
+      0x00, 0xff, 0x2f, 0x00, // end of track
+    ];
+    // prettier-ignore
+    const bytes = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, trackData.length,              // track length
+      ...trackData,
+    ]);
+    const result = midiFileToSequence(bytes);
+    expect(result.events.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMidiFile — track event parsing edge cases
+// ---------------------------------------------------------------------------
+
+describe('parseMidiFile — track event parsing', () => {
+  it('parses unknown meta events', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xff, 0x07, 0x03, 0x61, 0x62, 0x63, // type 0x07, length 3
+      0x00, 0xff, 0x2f, 0x00,                    // end of track
+    ];
+    const doc = parseMidiFile(buildSimpleMidi(trackData));
+    const track = doc.tracks[0]!;
+    const unknown = track.find((e) => e.type === 'unknownMeta');
+    expect(unknown).toBeDefined();
+    if (unknown?.type === 'unknownMeta') {
+      expect(unknown.metaType).toBe(0x07);
+    }
+  });
+
+  it('emits the end-of-track meta event as the final track event', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x90, 0x3c, 0x40, // note-on C4
+      0x60, 0x80, 0x3c, 0x40, // note-off C4
+      0x00, 0xff, 0x2f, 0x00, // end of track
+    ];
+    const doc = parseMidiFile(buildSimpleMidi(trackData));
+    const track = doc.tracks[0]!;
+    const last = track[track.length - 1];
+    expect(last?.type).toBe('endOfTrack');
+  });
+
+  it('parses note-off events (0x80)', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x90, 0x3c, 0x40, // note-on C4
+      0x60, 0x80, 0x3c, 0x40, // note-off C4
+      0x00, 0xff, 0x2f, 0x00, // end of track
+    ];
+    const doc = parseMidiFile(buildSimpleMidi(trackData));
+    const track = doc.tracks[0]!;
+    expect(track.find((e) => e.type === 'noteOff')).toBeDefined();
+  });
+
+  it('handles program change events (1 data byte)', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xc0, 0x00,       // program change
+      0x00, 0xff, 0x2f, 0x00, // end of track
+    ];
+    const doc = parseMidiFile(buildSimpleMidi(trackData));
+    expect(doc.tracks[0]).toBeDefined();
+  });
+
+  it('handles channel pressure events (1 data byte)', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xd0, 0x40,       // channel pressure
+      0x00, 0xff, 0x2f, 0x00, // end of track
+    ];
+    const doc = parseMidiFile(buildSimpleMidi(trackData));
+    expect(doc.tracks[0]).toBeDefined();
+  });
+
+  it('handles pitch bend events (2 data bytes)', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xe0, 0x00, 0x40, // pitch bend
+      0x00, 0xff, 0x2f, 0x00, // end of track
+    ];
+    const doc = parseMidiFile(buildSimpleMidi(trackData));
+    expect(doc.tracks[0]).toBeDefined();
+  });
+
+  it('throws RangeError on truncated meta event after type byte', () => {
+    // prettier-ignore
+    const truncated = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, 0x01,                          // track length = 1
+      0x00,                                            // delta 0, then no FF follows (truncated)
+    ]);
+    expect(() => parseMidiFile(truncated)).toThrow(RangeError);
+  });
+
+  it('throws TypeError when running status is used before any status byte', () => {
+    // prettier-ignore
+    const trackData = [
+      0x3c, 0x40,             // data bytes with no prior status byte
+      0x00, 0xff, 0x2f, 0x00, // end of track
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(TypeError);
+  });
+
+  it('throws RangeError on truncated note-on event (missing second data byte)', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x90, 0x3c, // note-on with only 1 data byte
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError when meta event is truncated (no VLQ for length)', () => {
+    // prettier-ignore
+    const truncated = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, 0x02,                          // track length = 2
+      0x00, 0xff,                                      // delta + FF, no meta type follows
+    ]);
+    expect(() => parseMidiFile(truncated)).toThrow(RangeError);
+  });
+
+  it('throws RangeError on truncated tempo meta', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xff, 0x51, 0x03, 0x07, 0xa1, // missing last byte
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError on truncated time signature meta', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xff, 0x58, 0x04, 0x04, 0x02, 0x18, // missing last byte
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError on truncated channel event (missing second data byte for note-off)', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x80, 0x3c, // note-off with only 1 data byte
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError on truncated data after delta time', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, // valid delta, but no event byte
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError on truncated channel event with running status (file shorter than declared)', () => {
+    // First event sets running status 0x90. Second uses running status with delta 0x78.
+    // Track DECLARES length=7 but the file only has 5 track bytes.
+    const trackData = [0x00, 0x90, 0x3c, 0x40, 0x78]; // 5 real bytes
+    // prettier-ignore
+    const bytes = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, 7,                             // declared as 7 but only 5 follow
+      ...trackData,
+    ]);
+    expect(() => parseMidiFile(bytes)).toThrow(RangeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom ticksPerQuarter option
+// ---------------------------------------------------------------------------
+
+describe('sequenceToMidiFile — custom ticksPerQuarter', () => {
+  it('uses custom ticksPerQuarter in the division field', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    const bytes = sequenceToMidiFile(seq, { ticksPerQuarter: 960 });
+    expect(bytes[12]).toBe(0x03);
+    expect(bytes[13]).toBe(0xc0);
+  });
+
+  it('round-trips with custom ticksPerQuarter', () => {
+    const c4 = Note.create({ note: 'C', octave: 4 });
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: c4,
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+          velocity: 60,
+        },
+      ],
+      { tempo: 120 },
+    );
+    const bytes = sequenceToMidiFile(seq, { ticksPerQuarter: 960 });
+    const result = midiFileToSequence(bytes);
+    expect(result.events.length).toBe(1);
+    expect(result.events[0]?.type).toBe('note');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// midiFileToSequence — invalid meter in file (catch branch)
+// ---------------------------------------------------------------------------
+
+describe('midiFileToSequence — invalid meter denominator', () => {
+  it('omits meter when the SMF time signature has an unsupported denominator exponent', () => {
+    // dd=7 means denominator = 2^7 = 128, which is not a valid Meter denominator.
+    // Meter.create should throw, and the catch block should silently omit the meter.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xff, 0x58, 0x04, 0x04, 0x07, 0x18, 0x08, // time sig: 4/128 (invalid)
+      0x00, 0xff, 0x2f, 0x00,                          // end of track
+    ];
+    // prettier-ignore
+    const bytes = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, trackData.length,              // track length
+      ...trackData,
+    ]);
+    const result = midiFileToSequence(bytes);
+    expect(result.meter).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom channel option
+// ---------------------------------------------------------------------------
+
+describe('sequenceToMidiFile — custom channel', () => {
+  it('uses custom MIDI channel for note events', () => {
+    const c4 = Note.create({ note: 'C', octave: 4 });
+    const seq = Sequence.create(
+      [{ type: 'note', note: c4, start: musicalTime(0, 1), duration: musicalTime(1, 4) }],
+      { tempo: 120 },
+    );
+    const bytes = sequenceToMidiFile(seq, { channel: 3 });
+    const doc = parseMidiFile(bytes);
+    const track = doc.tracks[0]!;
+    const noteOn = track.find((e) => e.type === 'noteOn');
+    expect(noteOn).toBeDefined();
+    if (noteOn?.type === 'noteOn') {
+      expect(noteOn.channel).toBe(3);
+    }
+  });
+});

--- a/src/midi-file/midi-file-decode.test.ts
+++ b/src/midi-file/midi-file-decode.test.ts
@@ -296,6 +296,134 @@ describe('parseMidiFile — track event parsing', () => {
     ]);
     expect(() => parseMidiFile(bytes)).toThrow(RangeError);
   });
+
+  it('throws RangeError when declared track length exceeds the file size', () => {
+    // prettier-ignore
+    const bytes = new Uint8Array([
+      0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, // MThd
+      0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,              // format=0, tracks=1, division=480
+      0x4d, 0x54, 0x72, 0x6b,                          // MTrk
+      0x00, 0x00, 0x00, 0xff,                          // declares 255-byte track, but no bytes follow
+    ]);
+    expect(() => parseMidiFile(bytes)).toThrow(RangeError);
+  });
+
+  it('throws RangeError when end-of-track meta has non-zero length', () => {
+    // FF 2F 01 00: end-of-track with metaLength=1 (invalid; must be 0)
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xff, 0x2f, 0x01, 0x00, // end-of-track with illegal payload byte
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError when meta payload exceeds track boundary', () => {
+    // Unknown meta (type 0x07) declaring length=10 but only 3 bytes remain in track.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xff, 0x07, 0x0a, 0x61, 0x62, 0x63, // length=10, only 3 payload bytes present
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError when a channel data byte is >= 0x80 (status-like, malformed stream)', () => {
+    // Note-on C4 with velocity 0x80 — velocity byte >= 0x80 is invalid per SMF spec.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x90, 0x3c, 0x80, // note-on, noteNumber=0x3c, velocity=0x80 (invalid)
+      0x00, 0xff, 0x2f, 0x00,
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError when a note-on note number byte is >= 0x80', () => {
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x90, 0x80, 0x40, // note-on, noteNumber=0x80 (invalid), velocity=64
+      0x00, 0xff, 0x2f, 0x00,
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError when a skipped-event data byte is >= 0x80 (pitch bend)', () => {
+    // Pitch bend (0xE0) with second data byte = 0x80 — invalid data byte.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xe0, 0x00, 0x80, // pitch bend, LSB=0x00, MSB=0x80 (invalid)
+      0x00, 0xff, 0x2f, 0x00,
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('throws RangeError on truncated skipped channel event (pitch bend, 2 bytes needed, 1 present)', () => {
+    // Pitch bend (0xE0) needs 2 data bytes; only 1 present before track end.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xe0, 0x00, // pitch bend with only 1 data byte in track
+    ];
+    expect(() => parseMidiFile(buildSimpleMidi(trackData))).toThrow(RangeError);
+  });
+
+  it('program-change advances byte pointer correctly (following noteOn decodes)', () => {
+    // Program change (0xC0) consumes exactly 1 data byte.
+    // A noteOn immediately after must decode correctly, proving the byte pointer advanced right.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xc0, 0x28,             // delta=0, program change ch0, program=40
+      0x00, 0x90, 0x3c, 0x40,       // delta=0, note-on ch0, C4 (0x3c=60), vel=64
+      0x60, 0x90, 0x3c, 0x00,       // delta=96, note-on vel=0 (note-off), C4
+      0x00, 0xff, 0x2f, 0x00,       // end of track
+    ];
+    const doc = parseMidiFile(buildSimpleMidi(trackData));
+    const track = doc.tracks[0]!;
+    const noteOn = track.find((e) => e.type === 'noteOn' && e.velocity > 0);
+    expect(noteOn).toBeDefined();
+    if (noteOn?.type === 'noteOn') {
+      expect(noteOn.noteNumber).toBe(0x3c);
+      expect(noteOn.velocity).toBe(0x40);
+      expect(noteOn.deltaTicks).toBe(0);
+    }
+  });
+
+  it('channel-pressure advances byte pointer correctly (following noteOn decodes)', () => {
+    // Channel pressure (0xD0) consumes exactly 1 data byte.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xd0, 0x40,             // delta=0, channel pressure ch0, value=64
+      0x00, 0x90, 0x3c, 0x40,       // delta=0, note-on ch0, C4, vel=64
+      0x60, 0x90, 0x3c, 0x00,       // delta=96, note-off C4
+      0x00, 0xff, 0x2f, 0x00,       // end of track
+    ];
+    const doc = parseMidiFile(buildSimpleMidi(trackData));
+    const track = doc.tracks[0]!;
+    const noteOn = track.find((e) => e.type === 'noteOn' && e.velocity > 0);
+    expect(noteOn).toBeDefined();
+    if (noteOn?.type === 'noteOn') {
+      expect(noteOn.noteNumber).toBe(0x3c);
+      expect(noteOn.velocity).toBe(0x40);
+      expect(noteOn.deltaTicks).toBe(0);
+    }
+  });
+
+  it('pitch-bend advances byte pointer correctly (following noteOn decodes)', () => {
+    // Pitch bend (0xE0) consumes exactly 2 data bytes.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0xe0, 0x00, 0x40,       // delta=0, pitch bend ch0, LSB=0, MSB=64
+      0x00, 0x90, 0x3c, 0x40,       // delta=0, note-on ch0, C4, vel=64
+      0x60, 0x90, 0x3c, 0x00,       // delta=96, note-off C4
+      0x00, 0xff, 0x2f, 0x00,       // end of track
+    ];
+    const doc = parseMidiFile(buildSimpleMidi(trackData));
+    const track = doc.tracks[0]!;
+    const noteOn = track.find((e) => e.type === 'noteOn' && e.velocity > 0);
+    expect(noteOn).toBeDefined();
+    if (noteOn?.type === 'noteOn') {
+      expect(noteOn.noteNumber).toBe(0x3c);
+      expect(noteOn.velocity).toBe(0x40);
+      expect(noteOn.deltaTicks).toBe(0);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -376,5 +504,50 @@ describe('sequenceToMidiFile — custom channel', () => {
     if (noteOn?.type === 'noteOn') {
       expect(noteOn.channel).toBe(3);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sequenceToMidiFile — option validation
+// ---------------------------------------------------------------------------
+
+describe('sequenceToMidiFile — option validation', () => {
+  const seq = Sequence.create([], { tempo: 120 });
+
+  it('throws RangeError for ticksPerQuarter = 0', () => {
+    expect(() => sequenceToMidiFile(seq, { ticksPerQuarter: 0 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for negative ticksPerQuarter', () => {
+    expect(() => sequenceToMidiFile(seq, { ticksPerQuarter: -1 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for fractional ticksPerQuarter', () => {
+    expect(() => sequenceToMidiFile(seq, { ticksPerQuarter: 480.5 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for ticksPerQuarter = 32768 (exceeds 0x7fff)', () => {
+    expect(() => sequenceToMidiFile(seq, { ticksPerQuarter: 32768 })).toThrow(RangeError);
+  });
+
+  it('accepts ticksPerQuarter = 32767 (0x7fff maximum)', () => {
+    expect(() => sequenceToMidiFile(seq, { ticksPerQuarter: 32767 })).not.toThrow();
+  });
+
+  it('throws RangeError for channel = 16', () => {
+    expect(() => sequenceToMidiFile(seq, { channel: 16 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for negative channel', () => {
+    expect(() => sequenceToMidiFile(seq, { channel: -1 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for fractional channel', () => {
+    expect(() => sequenceToMidiFile(seq, { channel: 1.5 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError when tempo yields microseconds exceeding 0xffffff (very slow BPM)', () => {
+    const slowSeq = Sequence.create([], { tempo: 0.001 });
+    expect(() => sequenceToMidiFile(slowSeq)).toThrow(RangeError);
   });
 });

--- a/src/midi-file/midi-file-encode.test.ts
+++ b/src/midi-file/midi-file-encode.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'bun:test';
+import { Note } from '../note.js';
+import { Chord } from '../chord.js';
+import { Sequence, musicalTime } from '../sequences/sequence.js';
+import { sequenceToMidiFile } from './encode.js';
+
+// ---------------------------------------------------------------------------
+// sequenceToMidiFile — velocity-0 rejection (Fix #5)
+//
+// A note-on with velocity 0 is treated as note-off by the MIDI spec.  The
+// SMF encoder must reject velocity 0 on note AND chord events rather than
+// silently emitting a note that is immediately muted.
+// ---------------------------------------------------------------------------
+
+describe('sequenceToMidiFile — velocity-0 rejection', () => {
+  it('throws RangeError when a note event has velocity 0', () => {
+    const c4 = Note.create({ note: 'C', octave: 4 });
+    // prettier-ignore
+    const noteVel0Seq = Sequence.create(
+      [{ type: 'note', note: c4, start: musicalTime(0, 1), duration: musicalTime(1, 4), velocity: 0 }],
+      { tempo: 120 },
+    );
+    expect(() => sequenceToMidiFile(noteVel0Seq)).toThrow(RangeError);
+    expect(() => sequenceToMidiFile(noteVel0Seq)).toThrow(/0 is interpreted as note-off/);
+  });
+
+  it('throws RangeError when a chord event has velocity 0', () => {
+    const cMaj = Chord.create({ note: 'C', octave: 4 }, 'major');
+    // prettier-ignore
+    const chordVel0Seq = Sequence.create(
+      [{ type: 'chord', chord: cMaj, start: musicalTime(0, 1), duration: musicalTime(1, 4), velocity: 0 }],
+      { tempo: 120 },
+    );
+    expect(() => sequenceToMidiFile(chordVel0Seq)).toThrow(RangeError);
+    expect(() => sequenceToMidiFile(chordVel0Seq)).toThrow(/0 is interpreted as note-off/);
+  });
+
+  it('accepts note event velocity 1 (lower boundary)', () => {
+    const c4 = Note.create({ note: 'C', octave: 4 });
+    // prettier-ignore
+    const noteVel1Seq = Sequence.create(
+      [{ type: 'note', note: c4, start: musicalTime(0, 1), duration: musicalTime(1, 4), velocity: 1 }],
+      { tempo: 120 },
+    );
+    expect(() => sequenceToMidiFile(noteVel1Seq)).not.toThrow();
+  });
+
+  it('accepts note event velocity 127 (upper boundary)', () => {
+    const c4 = Note.create({ note: 'C', octave: 4 });
+    // prettier-ignore
+    const noteVel127Seq = Sequence.create(
+      [{ type: 'note', note: c4, start: musicalTime(0, 1), duration: musicalTime(1, 4), velocity: 127 }],
+      { tempo: 120 },
+    );
+    expect(() => sequenceToMidiFile(noteVel127Seq)).not.toThrow();
+  });
+});

--- a/src/midi-file/midi-file.test.ts
+++ b/src/midi-file/midi-file.test.ts
@@ -1,0 +1,531 @@
+import { describe, it, expect } from 'bun:test';
+import { Note } from '../note.js';
+import { Chord } from '../chord.js';
+import { Sequence, musicalTime } from '../sequences/sequence.js';
+import { Meter } from '../meter.js';
+import { sequenceToMidiFile } from './encode.js';
+import { parseMidiFile, midiFileToSequence } from './decode.js';
+import { encodeVlq, decodeVlq, MAX_VLQ_VALUE } from './variable-length.js';
+
+// ---------------------------------------------------------------------------
+// VLQ tests
+// ---------------------------------------------------------------------------
+
+describe('encodeVlq', () => {
+  it('encodes 0 as [0x00]', () => {
+    expect(encodeVlq(0)).toEqual([0x00]);
+  });
+
+  it('encodes 127 as [0x7F]', () => {
+    expect(encodeVlq(127)).toEqual([0x7f]);
+  });
+
+  it('encodes 128 as [0x81, 0x00]', () => {
+    expect(encodeVlq(128)).toEqual([0x81, 0x00]);
+  });
+
+  it('encodes 8192 as [0xC0, 0x00]', () => {
+    expect(encodeVlq(8192)).toEqual([0xc0, 0x00]);
+  });
+
+  it('encodes 480 as [0x83, 0x60]', () => {
+    expect(encodeVlq(480)).toEqual([0x83, 0x60]);
+  });
+
+  it('encodes 0x0FFFFFFF (max) as 4 bytes', () => {
+    const result = encodeVlq(0x0fffffff);
+    expect(result).toEqual([0xff, 0xff, 0xff, 0x7f]);
+  });
+
+  it('throws RangeError for negative values', () => {
+    expect(() => encodeVlq(-1)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for values exceeding MAX_VLQ_VALUE', () => {
+    expect(() => encodeVlq(MAX_VLQ_VALUE + 1)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-integer values', () => {
+    expect(() => encodeVlq(1.5)).toThrow(RangeError);
+  });
+});
+
+describe('decodeVlq', () => {
+  it('decodes [0x00] as 0', () => {
+    expect(decodeVlq(new Uint8Array([0x00]), 0)).toEqual({ value: 0, bytesRead: 1 });
+  });
+
+  it('decodes [0x7F] as 127', () => {
+    expect(decodeVlq(new Uint8Array([0x7f]), 0)).toEqual({ value: 127, bytesRead: 1 });
+  });
+
+  it('decodes [0x81, 0x00] as 128', () => {
+    expect(decodeVlq(new Uint8Array([0x81, 0x00]), 0)).toEqual({ value: 128, bytesRead: 2 });
+  });
+
+  it('decodes [0xC0, 0x00] as 8192', () => {
+    expect(decodeVlq(new Uint8Array([0xc0, 0x00]), 0)).toEqual({ value: 8192, bytesRead: 2 });
+  });
+
+  it('decodes [0x83, 0x60] as 480', () => {
+    expect(decodeVlq(new Uint8Array([0x83, 0x60]), 0)).toEqual({ value: 480, bytesRead: 2 });
+  });
+
+  it('decodes [0xFF, 0xFF, 0xFF, 0x7F] as 0x0FFFFFFF', () => {
+    expect(decodeVlq(new Uint8Array([0xff, 0xff, 0xff, 0x7f]), 0)).toEqual({
+      value: 0x0fffffff,
+      bytesRead: 4,
+    });
+  });
+
+  it('respects the offset parameter', () => {
+    const data = new Uint8Array([0x00, 0x83, 0x60]);
+    expect(decodeVlq(data, 1)).toEqual({ value: 480, bytesRead: 2 });
+  });
+
+  it('throws RangeError on truncated data', () => {
+    expect(() => decodeVlq(new Uint8Array([0x81]), 0)).toThrow(RangeError);
+  });
+
+  it('throws RangeError on empty array at offset', () => {
+    expect(() => decodeVlq(new Uint8Array([]), 0)).toThrow(RangeError);
+  });
+
+  it('throws RangeError when VLQ exceeds 4 bytes', () => {
+    // 5-byte continuation: all high bits set
+    expect(() => decodeVlq(new Uint8Array([0x81, 0x80, 0x80, 0x80, 0x00]), 0)).toThrow(RangeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SMF header byte verification (external ground truth)
+// ---------------------------------------------------------------------------
+
+describe('sequenceToMidiFile — MThd header bytes', () => {
+  const seq = Sequence.create([], { tempo: 120 });
+  const bytes = sequenceToMidiFile(seq);
+
+  it('starts with MThd (0x4D546864)', () => {
+    expect(bytes[0]).toBe(0x4d);
+    expect(bytes[1]).toBe(0x54);
+    expect(bytes[2]).toBe(0x68);
+    expect(bytes[3]).toBe(0x64);
+  });
+
+  it('has header length 6', () => {
+    expect(bytes[4]).toBe(0x00);
+    expect(bytes[5]).toBe(0x00);
+    expect(bytes[6]).toBe(0x00);
+    expect(bytes[7]).toBe(0x06);
+  });
+
+  it('has format 0', () => {
+    expect(bytes[8]).toBe(0x00);
+    expect(bytes[9]).toBe(0x00);
+  });
+
+  it('has ntrks = 1', () => {
+    expect(bytes[10]).toBe(0x00);
+    expect(bytes[11]).toBe(0x01);
+  });
+
+  it('has division 480 (0x01E0)', () => {
+    expect(bytes[12]).toBe(0x01);
+    expect(bytes[13]).toBe(0xe0);
+  });
+
+  it('has MTrk marker after header', () => {
+    expect(bytes[14]).toBe(0x4d);
+    expect(bytes[15]).toBe(0x54);
+    expect(bytes[16]).toBe(0x72);
+    expect(bytes[17]).toBe(0x6b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tempo encoding (external ground truth)
+// ---------------------------------------------------------------------------
+
+describe('sequenceToMidiFile — tempo meta bytes', () => {
+  it('encodes 120 BPM as 500000 us (0x07A120)', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    const bytes = sequenceToMidiFile(seq);
+
+    // Track data starts at offset 22 (14 header + 4 MTrk + 4 track length)
+    const trackStart = 22;
+
+    // First event: delta=0 (0x00), then FF 51 03 tt tt tt
+    expect(bytes[trackStart]).toBe(0x00); // delta 0
+    expect(bytes[trackStart + 1]).toBe(0xff); // meta
+    expect(bytes[trackStart + 2]).toBe(0x51); // tempo type
+    expect(bytes[trackStart + 3]).toBe(0x03); // length 3
+    // 500000 = 0x07A120
+    expect(bytes[trackStart + 4]).toBe(0x07);
+    expect(bytes[trackStart + 5]).toBe(0xa1);
+    expect(bytes[trackStart + 6]).toBe(0x20);
+  });
+
+  it('encodes 60 BPM as 1000000 us (0x0F4240)', () => {
+    const seq = Sequence.create([], { tempo: 60 });
+    const bytes = sequenceToMidiFile(seq);
+    const trackStart = 22;
+
+    expect(bytes[trackStart + 4]).toBe(0x0f);
+    expect(bytes[trackStart + 5]).toBe(0x42);
+    expect(bytes[trackStart + 6]).toBe(0x40);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Time signature encoding
+// ---------------------------------------------------------------------------
+
+describe('sequenceToMidiFile — time signature meta bytes', () => {
+  it('encodes 4/4 as FF 58 04 04 02 18 08', () => {
+    const seq = Sequence.create([], { tempo: 120, meter: Meter.create('4/4') });
+    const bytes = sequenceToMidiFile(seq);
+    const trackStart = 22;
+
+    // After the tempo event (7 bytes: delta + FF 51 03 t t t), comes time sig
+    const timeSigOffset = trackStart + 7;
+
+    expect(bytes[timeSigOffset]).toBe(0x00); // delta 0
+    expect(bytes[timeSigOffset + 1]).toBe(0xff);
+    expect(bytes[timeSigOffset + 2]).toBe(0x58);
+    expect(bytes[timeSigOffset + 3]).toBe(0x04);
+    expect(bytes[timeSigOffset + 4]).toBe(0x04); // nn = 4
+    expect(bytes[timeSigOffset + 5]).toBe(0x02); // dd = 2 (2^2 = 4)
+    expect(bytes[timeSigOffset + 6]).toBe(0x18); // cc = 24
+    expect(bytes[timeSigOffset + 7]).toBe(0x08); // bb = 8
+  });
+
+  it('encodes 3/4 with dd = 2', () => {
+    const seq = Sequence.create([], { tempo: 120, meter: Meter.create('3/4') });
+    const bytes = sequenceToMidiFile(seq);
+    const trackStart = 22;
+    const timeSigOffset = trackStart + 7;
+
+    expect(bytes[timeSigOffset + 4]).toBe(0x03); // nn = 3
+    expect(bytes[timeSigOffset + 5]).toBe(0x02); // dd = 2 (2^2 = 4)
+  });
+
+  it('encodes 6/8 with dd = 3', () => {
+    const seq = Sequence.create([], { tempo: 120, meter: Meter.create('6/8') });
+    const bytes = sequenceToMidiFile(seq);
+    const trackStart = 22;
+    const timeSigOffset = trackStart + 7;
+
+    expect(bytes[timeSigOffset + 4]).toBe(0x06); // nn = 6
+    expect(bytes[timeSigOffset + 5]).toBe(0x03); // dd = 3 (2^3 = 8)
+  });
+
+  it('uses default 4/4 when no meter is set', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    const bytes = sequenceToMidiFile(seq);
+    const trackStart = 22;
+    const timeSigOffset = trackStart + 7;
+
+    expect(bytes[timeSigOffset + 4]).toBe(0x04); // nn = 4
+    expect(bytes[timeSigOffset + 5]).toBe(0x02); // dd = 2
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Note event encoding
+// ---------------------------------------------------------------------------
+
+describe('sequenceToMidiFile — note events', () => {
+  it('produces deterministic output for identical sequences', () => {
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: Note.create({ note: 'C', octave: 4 }),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+        },
+      ],
+      { tempo: 120 },
+    );
+    const a = sequenceToMidiFile(seq);
+    const b = sequenceToMidiFile(seq);
+    expect(a).toEqual(b);
+  });
+
+  it('encodes note-on and note-off for a single note', () => {
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: Note.create({ note: 'C', octave: 4 }),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+        },
+      ],
+      { tempo: 120 },
+    );
+    const bytes = sequenceToMidiFile(seq);
+    const doc = parseMidiFile(bytes);
+
+    expect(doc.format).toBe(0);
+
+    const track = doc.tracks[0];
+    expect(track).toBeDefined();
+
+    // Should contain tempo, timeSig, noteOn, noteOff (vel 0), endOfTrack
+    const noteOns = track!.filter((e) => e.type === 'noteOn');
+    const noteOffs = track!.filter(
+      (e) => e.type === 'noteOn' && 'velocity' in e && e.velocity === 0,
+    );
+
+    expect(noteOns.length).toBeGreaterThanOrEqual(1);
+    expect(noteOffs.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMidiFile validation
+// ---------------------------------------------------------------------------
+
+describe('parseMidiFile — validation', () => {
+  it('throws RangeError on data shorter than 14 bytes', () => {
+    expect(() => parseMidiFile(new Uint8Array([0x4d, 0x54]))).toThrow(RangeError);
+  });
+
+  it('throws TypeError when MThd magic is wrong', () => {
+    const bad = new Uint8Array(14);
+    bad[0] = 0x00; // not 'M'
+    expect(() => parseMidiFile(bad)).toThrow(TypeError);
+  });
+
+  it('throws RangeError on invalid header length < 6', () => {
+    const bytes = new Uint8Array(14);
+    bytes[0] = 0x4d;
+    bytes[1] = 0x54;
+    bytes[2] = 0x68;
+    bytes[3] = 0x64; // MThd
+    bytes[7] = 4; // length = 4 (too short)
+    expect(() => parseMidiFile(bytes)).toThrow(RangeError);
+  });
+
+  it('throws TypeError for unsupported format (2)', () => {
+    const bytes = new Uint8Array(14);
+    bytes[0] = 0x4d;
+    bytes[1] = 0x54;
+    bytes[2] = 0x68;
+    bytes[3] = 0x64;
+    bytes[7] = 6; // header length = 6
+    bytes[9] = 0x02; // format = 2
+    bytes[11] = 0x01; // ntrks = 1
+    bytes[12] = 0x01;
+    bytes[13] = 0xe0; // division = 480
+    expect(() => parseMidiFile(bytes)).toThrow(TypeError);
+  });
+
+  it('throws TypeError for SMPTE time code (high bit set in division)', () => {
+    const bytes = new Uint8Array(14);
+    bytes[0] = 0x4d;
+    bytes[1] = 0x54;
+    bytes[2] = 0x68;
+    bytes[3] = 0x64;
+    bytes[7] = 6;
+    bytes[9] = 0x00; // format 0
+    bytes[11] = 0x00; // ntrks = 0
+    bytes[12] = 0xe4;
+    bytes[13] = 0x00; // high bit set
+    expect(() => parseMidiFile(bytes)).toThrow(TypeError);
+  });
+
+  it('throws TypeError when MTrk marker is missing', () => {
+    // Build a minimal MIDI with ntrks=1 but bad track marker
+    const bytes = new Uint8Array(22);
+    bytes[0] = 0x4d;
+    bytes[1] = 0x54;
+    bytes[2] = 0x68;
+    bytes[3] = 0x64;
+    bytes[7] = 6;
+    bytes[9] = 0x00; // format 0
+    bytes[11] = 0x01; // ntrks = 1
+    bytes[12] = 0x01;
+    bytes[13] = 0xe0;
+    // bad track magic
+    bytes[14] = 0x00;
+    expect(() => parseMidiFile(bytes)).toThrow(TypeError);
+  });
+
+  it('throws RangeError on truncated track chunk header', () => {
+    // ntrks = 1 but only enough bytes for header
+    const bytes = new Uint8Array(14);
+    bytes[0] = 0x4d;
+    bytes[1] = 0x54;
+    bytes[2] = 0x68;
+    bytes[3] = 0x64;
+    bytes[7] = 6;
+    bytes[9] = 0x00;
+    bytes[11] = 0x01; // ntrks = 1
+    bytes[12] = 0x01;
+    bytes[13] = 0xe0;
+    // Only 14 bytes total, no room for track header
+    expect(() => parseMidiFile(bytes)).toThrow(RangeError);
+  });
+
+  it('throws RangeError on file shorter than minimum 14 bytes (e.g. 6 bytes)', () => {
+    // The 14-byte guard fires before any uint32/uint16 reads
+    const bytes = new Uint8Array([0x4d, 0x54, 0x68, 0x64, 0x00, 0x00]);
+    expect(() => parseMidiFile(bytes)).toThrow(RangeError);
+  });
+
+  it('throws RangeError on file with 9 bytes (still below 14-byte minimum)', () => {
+    const bytes = new Uint8Array([0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00]);
+    expect(() => parseMidiFile(bytes)).toThrow(RangeError);
+  });
+
+  it('throws RangeError on truncated channel event with running status (file shorter than declared track length)', () => {
+    // The first event sets running status 0x90. The second event uses running status
+    // with delta 0x78. The track DECLARES length=7 but the file only has 5 track bytes.
+    // After reading the delta VLQ, pos falls outside the actual file data, causing
+    // data[pos] to be undefined when parseChannelEvent reads b0.
+    const trackData = [0x00, 0x90, 0x3c, 0x40, 0x78]; // 5 real bytes
+    const declaredTrackLength = 7; // lies — 2 more bytes expected but absent
+    const bytes = new Uint8Array([
+      0x4d,
+      0x54,
+      0x68,
+      0x64,
+      0x00,
+      0x00,
+      0x00,
+      0x06,
+      0x00,
+      0x00,
+      0x00,
+      0x01,
+      0x01,
+      0xe0,
+      0x4d,
+      0x54,
+      0x72,
+      0x6b,
+      0x00,
+      0x00,
+      0x00,
+      declaredTrackLength,
+      ...trackData,
+    ]);
+    expect(() => parseMidiFile(bytes)).toThrow(RangeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip test
+// ---------------------------------------------------------------------------
+
+describe('round-trip: sequenceToMidiFile -> midiFileToSequence', () => {
+  it('preserves note pitches, velocities, tempo, and meter for a 2-note sequence', () => {
+    const c4 = Note.create({ note: 'C', octave: 4 });
+    const e4 = Note.create({ note: 'E', octave: 4 });
+    const meter = Meter.create('4/4');
+
+    const original = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: c4,
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+          velocity: 80,
+        },
+        {
+          type: 'note',
+          note: e4,
+          start: musicalTime(1, 4),
+          duration: musicalTime(1, 4),
+          velocity: 90,
+        },
+      ],
+      { tempo: 120, meter },
+    );
+
+    const bytes = sequenceToMidiFile(original);
+    const reconstructed = midiFileToSequence(bytes);
+
+    expect(reconstructed.tempo).toBe(120);
+    expect(reconstructed.meter?.numerator).toBe(4);
+    expect(reconstructed.meter?.denominator).toBe(4);
+    expect(reconstructed.events.length).toBe(2);
+
+    const e0 = reconstructed.events[0];
+    const e1 = reconstructed.events[1];
+
+    expect(e0?.type).toBe('note');
+    expect(e1?.type).toBe('note');
+
+    if (e0?.type === 'note') {
+      expect(e0.note.midi).toBe(c4.midi);
+      expect(e0.velocity).toBe(80);
+      expect(e0.start.numerator).toBe(0);
+    }
+
+    if (e1?.type === 'note') {
+      expect(e1.note.midi).toBe(e4.midi);
+      expect(e1.velocity).toBe(90);
+      // start = 1/4 whole note
+      expect(e1.start.numerator / e1.start.denominator).toBeCloseTo(0.25, 5);
+    }
+  });
+
+  it('preserves tempo through round-trip at 90 BPM', () => {
+    const seq = Sequence.create([], { tempo: 90 });
+    const bytes = sequenceToMidiFile(seq);
+    const result = midiFileToSequence(bytes);
+    expect(result.tempo).toBe(90);
+  });
+
+  it('uses defaultTempo option when no tempo meta is present', () => {
+    // Build a minimal MIDI with no tempo meta event
+    const seq = Sequence.create([], { tempo: 120 });
+    const bytes = sequenceToMidiFile(seq);
+    // Parse it but override default
+    const result = midiFileToSequence(bytes, { defaultTempo: 100 });
+    // The file has a real tempo meta (120 BPM), so result should be 120
+    expect(result.tempo).toBe(120);
+  });
+
+  it('round-trips a chord event as individual note events', () => {
+    const cMaj = Chord.create({ note: 'C', octave: 4 }, 'major');
+    const seq = Sequence.create(
+      [
+        {
+          type: 'chord',
+          chord: cMaj,
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 2),
+          velocity: 70,
+        },
+      ],
+      { tempo: 120 },
+    );
+    const bytes = sequenceToMidiFile(seq);
+    const reconstructed = midiFileToSequence(bytes);
+
+    // C major has 3 notes
+    expect(reconstructed.events.length).toBe(3);
+    expect(reconstructed.events.every((e) => e.type === 'note')).toBe(true);
+  });
+
+  it('handles rest events (skips them in MIDI output)', () => {
+    const c4 = Note.create({ note: 'C', octave: 4 });
+    const seq = Sequence.create(
+      [
+        { type: 'note', note: c4, start: musicalTime(0, 1), duration: musicalTime(1, 4) },
+        { type: 'rest', start: musicalTime(1, 4), duration: musicalTime(1, 4) },
+      ],
+      { tempo: 120 },
+    );
+    const bytes = sequenceToMidiFile(seq);
+    const reconstructed = midiFileToSequence(bytes);
+
+    // Only 1 note event (rest is not encoded)
+    expect(reconstructed.events.length).toBe(1);
+  });
+});

--- a/src/midi-file/midi-file.test.ts
+++ b/src/midi-file/midi-file.test.ts
@@ -529,3 +529,98 @@ describe('round-trip: sequenceToMidiFile -> midiFileToSequence', () => {
     expect(reconstructed.events.length).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// midiFileToSequence — overlapping notes (same pitch, FIFO pairing)
+// ---------------------------------------------------------------------------
+
+// prettier-ignore
+function buildOverlapMidi(trackData: number[]): Uint8Array {
+  return new Uint8Array([
+    0x4d, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06,
+    0x00, 0x00, 0x00, 0x01, 0x01, 0xe0,
+    0x4d, 0x54, 0x72, 0x6b,
+    0x00, 0x00, 0x00, trackData.length,
+    ...trackData,
+  ]);
+}
+
+describe('midiFileToSequence — overlapping same-pitch notes', () => {
+  it('pairs two overlapping note-ons of the same pitch+channel by FIFO order', () => {
+    // Two note-ons at ticks 0 and 96 (same pitch C4, same channel), then two
+    // note-offs at ticks 192 and 288.  FIFO pairing: note1=(0,192), note2=(96,288).
+    // division=480; whole=1920 ticks.
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x90, 0x3c, 0x40,  // tick   0: note-on  ch0 C4 vel=64
+      0x60, 0x90, 0x3c, 0x50,  // tick  96: note-on  ch0 C4 vel=80
+      0x60, 0x90, 0x3c, 0x00,  // tick 192: note-on vel=0 (note-off) ch0 C4
+      0x60, 0x90, 0x3c, 0x00,  // tick 288: note-on vel=0 (note-off) ch0 C4
+      0x00, 0xff, 0x2f, 0x00,
+    ];
+    const result = midiFileToSequence(buildOverlapMidi(trackData));
+    expect(result.events.length).toBe(2);
+
+    const sorted = result.events.toSorted(
+      (a, b) => a.start.numerator / a.start.denominator - b.start.numerator / b.start.denominator,
+    );
+    const note1 = sorted[0];
+    const note2 = sorted[1];
+
+    // note1: onset tick 0, off tick 192, vel 64
+    expect(note1?.type).toBe('note');
+    if (note1?.type === 'note') {
+      expect(note1.note.midi).toBe(60);
+      expect(note1.start.numerator / note1.start.denominator).toBe(0);
+      expect(note1.duration.numerator / note1.duration.denominator).toBeCloseTo(192 / 1920, 6);
+      expect(note1.velocity).toBe(64);
+    }
+
+    // note2: onset tick 96, off tick 288, vel 80
+    expect(note2?.type).toBe('note');
+    if (note2?.type === 'note') {
+      expect(note2.note.midi).toBe(60);
+      expect(note2.start.numerator / note2.start.denominator).toBeCloseTo(96 / 1920, 6);
+      expect(note2.duration.numerator / note2.duration.denominator).toBeCloseTo(192 / 1920, 6);
+      expect(note2.velocity).toBe(80);
+    }
+  });
+
+  it('same pitch on different channels does not collide (ch0 and ch1 pair independently)', () => {
+    // Absolute ticks (division=480, whole=1920 ticks):
+    //   tick  0: note-on  ch0 C4 vel=64  (delta=0x00)
+    //   tick 48: note-on  ch1 C4 vel=80  (delta=0x30=48)
+    //   tick144: note-off ch0 C4         (delta=0x60=96)
+    //   tick192: note-off ch1 C4         (delta=0x30=48)
+    // ch0 note: start=0, duration=144 ticks = 144/1920
+    // ch1 note: start=48 ticks = 48/1920, duration=144 ticks = 144/1920
+    // prettier-ignore
+    const trackData = [
+      0x00, 0x90, 0x3c, 0x40,  // tick  0:  note-on  ch0 C4 vel=64
+      0x30, 0x91, 0x3c, 0x50,  // tick 48:  note-on  ch1 C4 vel=80
+      0x60, 0x90, 0x3c, 0x00,  // tick144:  note-off ch0 C4
+      0x30, 0x91, 0x3c, 0x00,  // tick192:  note-off ch1 C4
+      0x00, 0xff, 0x2f, 0x00,
+    ];
+    const result = midiFileToSequence(buildOverlapMidi(trackData));
+    expect(result.events.length).toBe(2);
+
+    const sorted = result.events.toSorted(
+      (a, b) => a.start.numerator / a.start.denominator - b.start.numerator / b.start.denominator,
+    );
+    const note1 = sorted[0];
+    const note2 = sorted[1];
+
+    if (note1?.type === 'note') {
+      expect(note1.note.midi).toBe(60);
+      expect(note1.start.numerator / note1.start.denominator).toBe(0);
+      expect(note1.duration.numerator / note1.duration.denominator).toBeCloseTo(144 / 1920, 6);
+    }
+
+    if (note2?.type === 'note') {
+      expect(note2.note.midi).toBe(60);
+      expect(note2.start.numerator / note2.start.denominator).toBeCloseTo(48 / 1920, 6);
+      expect(note2.duration.numerator / note2.duration.denominator).toBeCloseTo(144 / 1920, 6);
+    }
+  });
+});

--- a/src/midi-file/types.ts
+++ b/src/midi-file/types.ts
@@ -1,0 +1,157 @@
+/**
+ * Domain types for Standard MIDI File (SMF) documents.
+ */
+
+// ---------------------------------------------------------------------------
+// MIDI event types
+// ---------------------------------------------------------------------------
+
+/**
+ * A raw MIDI note-on event, parsed from an SMF track.
+ */
+export type MidiNoteOnEvent = {
+  /** Discriminant. */
+  readonly type: 'noteOn';
+  /** Delta time in ticks from the previous event. */
+  readonly deltaTicks: number;
+  /** MIDI channel (0-indexed, 0..15). */
+  readonly channel: number;
+  /** MIDI note number (0..127). */
+  readonly noteNumber: number;
+  /** Velocity (0..127). A velocity of 0 is equivalent to note-off. */
+  readonly velocity: number;
+};
+
+/**
+ * A raw MIDI note-off event, parsed from an SMF track.
+ */
+export type MidiNoteOffEvent = {
+  /** Discriminant. */
+  readonly type: 'noteOff';
+  /** Delta time in ticks from the previous event. */
+  readonly deltaTicks: number;
+  /** MIDI channel (0-indexed, 0..15). */
+  readonly channel: number;
+  /** MIDI note number (0..127). */
+  readonly noteNumber: number;
+  /** Velocity (0..127). */
+  readonly velocity: number;
+};
+
+/**
+ * A MIDI tempo meta event (FF 51 03 tt tt tt).
+ */
+export type MidiTempoEvent = {
+  /** Discriminant. */
+  readonly type: 'tempo';
+  /** Delta time in ticks from the previous event. */
+  readonly deltaTicks: number;
+  /** Microseconds per quarter note. */
+  readonly microsecondsPerQuarter: number;
+};
+
+/**
+ * A MIDI time signature meta event (FF 58 04 nn dd cc bb).
+ */
+export type MidiTimeSignatureEvent = {
+  /** Discriminant. */
+  readonly type: 'timeSignature';
+  /** Delta time in ticks from the previous event. */
+  readonly deltaTicks: number;
+  /** Numerator of the time signature. */
+  readonly numerator: number;
+  /** Denominator of the time signature (2^dd). */
+  readonly denominator: number;
+  /** MIDI clocks per metronome click. */
+  readonly clocksPerClick: number;
+  /** 32nd notes per MIDI quarter note. */
+  readonly thirtySecondNotesPerQuarter: number;
+};
+
+/**
+ * End-of-track meta event (FF 2F 00).
+ */
+export type MidiEndOfTrackEvent = {
+  /** Discriminant. */
+  readonly type: 'endOfTrack';
+  /** Delta time in ticks from the previous event. */
+  readonly deltaTicks: number;
+};
+
+/**
+ * Any other meta event (unknown type).
+ */
+export type MidiUnknownMetaEvent = {
+  /** Discriminant. */
+  readonly type: 'unknownMeta';
+  /** Delta time in ticks. */
+  readonly deltaTicks: number;
+  /** The raw meta type byte. */
+  readonly metaType: number;
+  /** The raw data bytes. */
+  readonly data: Uint8Array;
+};
+
+/**
+ * A union of all parsed MIDI track events.
+ */
+export type MidiTrackEvent =
+  | MidiNoteOnEvent
+  | MidiNoteOffEvent
+  | MidiTempoEvent
+  | MidiTimeSignatureEvent
+  | MidiEndOfTrackEvent
+  | MidiUnknownMetaEvent;
+
+// ---------------------------------------------------------------------------
+// MIDI file document
+// ---------------------------------------------------------------------------
+
+/**
+ * A parsed Standard MIDI File document.
+ */
+export type MidiFileDocument = {
+  /**
+   * SMF format type: 0 = single track, 1 = multi-track synchronous.
+   */
+  readonly format: 0 | 1;
+  /**
+   * Ticks per quarter note (the `division` field in the SMF header).
+   */
+  readonly ticksPerQuarter: number;
+  /**
+   * The parsed tracks, each an array of timed events.
+   */
+  readonly tracks: readonly (readonly MidiTrackEvent[])[];
+};
+
+// ---------------------------------------------------------------------------
+// Sequence-to-MIDI options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link sequenceToMidiFile}.
+ */
+export type SequenceToMidiOptions = {
+  /**
+   * Ticks per quarter note for the output file.
+   * @defaultValue 480
+   */
+  readonly ticksPerQuarter?: number;
+  /**
+   * MIDI channel to use for note events (0-indexed, 0..15).
+   * @defaultValue 0
+   */
+  readonly channel?: number;
+};
+
+/**
+ * Options for {@link midiFileToSequence}.
+ */
+export type MidiFileToSequenceOptions = {
+  /**
+   * Default tempo in BPM if no tempo meta event is present.
+   * @defaultValue 120
+   */
+  readonly defaultTempo?: number;
+};

--- a/src/midi-file/variable-length.ts
+++ b/src/midi-file/variable-length.ts
@@ -1,0 +1,87 @@
+/**
+ * MIDI variable-length quantity (VLQ) encode and decode utilities.
+ *
+ * A VLQ encodes an unsigned integer using 7 bits per byte, with the high bit
+ * of each byte set to 1 for all continuation bytes and 0 for the final byte.
+ *
+ * Maximum representable value: 0x0FFFFFFF (4 bytes).
+ */
+
+/**
+ * The maximum value representable as a 4-byte MIDI VLQ.
+ */
+export const MAX_VLQ_VALUE = 0x0fffffff;
+
+/**
+ * Encodes an unsigned integer as a MIDI variable-length quantity.
+ *
+ * @param value The integer to encode (must be in 0..0x0FFFFFFF).
+ * @returns The VLQ-encoded bytes.
+ * @throws {RangeError} When the value exceeds the maximum VLQ range.
+ */
+export function encodeVlq(value: number): readonly number[] {
+  if (!Number.isInteger(value) || value < 0 || value > MAX_VLQ_VALUE) {
+    throw new RangeError(`VLQ value must be an integer in 0..${MAX_VLQ_VALUE}, received ${value}.`);
+  }
+
+  if (value === 0) return [0x00];
+
+  const bytes: number[] = [];
+  let remaining = value;
+
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0x7f);
+    remaining >>= 7;
+  }
+
+  // Set continuation bit on all but the last byte.
+  for (let i = 0; i < bytes.length - 1; i++) {
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    bytes[i] = bytes[i]! | 0x80;
+  }
+
+  return bytes;
+}
+
+/**
+ * Result of decoding a VLQ from a byte array.
+ */
+export type VlqDecodeResult = {
+  /** The decoded integer value. */
+  readonly value: number;
+  /** The number of bytes consumed. */
+  readonly bytesRead: number;
+};
+
+/**
+ * Decodes a MIDI variable-length quantity from a byte array at the given offset.
+ *
+ * @param data The byte array to read from.
+ * @param offset The byte offset to start reading at.
+ * @returns The decoded value and the number of bytes consumed.
+ * @throws {RangeError} When the VLQ exceeds the 4-byte maximum or the data is truncated.
+ */
+export function decodeVlq(data: Uint8Array, offset: number): VlqDecodeResult {
+  let value = 0;
+  let bytesRead = 0;
+
+  for (;;) {
+    if (offset + bytesRead >= data.length) {
+      throw new RangeError(`Truncated VLQ at offset ${offset + bytesRead}.`);
+    }
+
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const byte = data[offset + bytesRead]!;
+    bytesRead++;
+
+    value = (value << 7) | (byte & 0x7f);
+
+    if (bytesRead > 4) {
+      throw new RangeError(`VLQ exceeds maximum 4-byte length at offset ${offset}.`);
+    }
+
+    if ((byte & 0x80) === 0) break;
+  }
+
+  return { value, bytesRead };
+}

--- a/src/midi-file/variable-length.ts
+++ b/src/midi-file/variable-length.ts
@@ -58,15 +58,23 @@ export type VlqDecodeResult = {
  *
  * @param data The byte array to read from.
  * @param offset The byte offset to start reading at.
+ * @param limit The exclusive upper bound the VLQ must stay within. Defaults to
+ *   `data.length`. Pass a track `end` to keep a meta-length VLQ from reading
+ *   bytes that belong to the next chunk.
  * @returns The decoded value and the number of bytes consumed.
- * @throws {RangeError} When the VLQ exceeds the 4-byte maximum or the data is truncated.
+ * @throws {RangeError} When the VLQ exceeds the 4-byte maximum, is truncated, or
+ *   would read past `limit`.
  */
-export function decodeVlq(data: Uint8Array, offset: number): VlqDecodeResult {
+export function decodeVlq(
+  data: Uint8Array,
+  offset: number,
+  limit: number = data.length,
+): VlqDecodeResult {
   let value = 0;
   let bytesRead = 0;
 
   for (;;) {
-    if (offset + bytesRead >= data.length) {
+    if (offset + bytesRead >= limit) {
       throw new RangeError(`Truncated VLQ at offset ${offset + bytesRead}.`);
     }
 

--- a/src/midi/index.ts
+++ b/src/midi/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Web MIDI message helpers — pure MIDI parsing, note conversion, and active-note
+ * state model.
+ *
+ * Import as `octavian/midi` (this is a subpath export, not part of the root
+ * barrel at `octavian`). The root `src/index.ts` MUST NOT re-export from
+ * this module.
+ *
+ * Import path: `octavian/midi`
+ */
+
+// Values first, then types.
+
+export { parseMidiMessage } from './parse.js';
+
+export { messageToNote } from './note-helpers.js';
+
+export {
+  createMidiState,
+  applyMidiMessage,
+  notesFromActiveMidiState,
+  chordFromActiveMidiState,
+} from './state.js';
+
+export { sequenceToMidiMessages } from './sequence-converter.js';
+
+export { SUSTAIN_CONTROLLER, SUSTAIN_THRESHOLD } from './types.js';
+
+export type {
+  MidiMessage,
+  NoteOnMessage,
+  NoteOffMessage,
+  ControlChangeMessage,
+  ProgramChangeMessage,
+  PitchBendMessage,
+} from './types.js';
+
+export type { MessageToNoteOptions } from './note-helpers.js';
+
+export type { MidiState, ActiveMidiStateOptions } from './state.js';
+
+export type { SequenceToMidiMessagesOptions, TimedMidiMessage } from './sequence-converter.js';

--- a/src/midi/note-helpers.ts
+++ b/src/midi/note-helpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Helpers for converting MIDI messages to music-theory {@link Note} objects.
+ */
+
+import { Note } from '../note.js';
+import type { AccidentalPreference } from '../key-signatures.js';
+import type { MidiMessage } from './types.js';
+
+// ---------------------------------------------------------------------------
+// messageToNote options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link messageToNote}.
+ */
+export type MessageToNoteOptions = {
+  /**
+   * Whether to prefer sharps or flats when spelling the note.
+   * Defaults to `'sharps'`.
+   */
+  readonly accidentalPreference?: AccidentalPreference;
+};
+
+// ---------------------------------------------------------------------------
+// messageToNote
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a Note-On or Note-Off message to the corresponding {@link Note}.
+ *
+ * Returns `null` for Control Change, Program Change, and Pitch Bend messages,
+ * which carry no note pitch.
+ *
+ * @param message The parsed MIDI message.
+ * @param options Optional spelling preference for accidentals.
+ * @returns The corresponding note, or `null` when the message type is not note-bearing.
+ */
+export function messageToNote(message: MidiMessage, options?: MessageToNoteOptions): Note | null {
+  if (message.type !== 'noteOn' && message.type !== 'noteOff') {
+    return null;
+  }
+
+  const preference = options?.accidentalPreference ?? 'sharps';
+  return Note.fromMidi(message.note, preference);
+}

--- a/src/midi/parse.test.ts
+++ b/src/midi/parse.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for parseMidiMessage and messageToNote.
+ *
+ * Ground truth values are asserted against the MIDI specification byte values,
+ * not self-consistent recomputations.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { parseMidiMessage } from './parse.js';
+import { messageToNote } from './note-helpers.js';
+import { SUSTAIN_CONTROLLER, SUSTAIN_THRESHOLD } from './types.js';
+
+// ---------------------------------------------------------------------------
+// parseMidiMessage — Note On
+// ---------------------------------------------------------------------------
+
+describe('parseMidiMessage — Note On', () => {
+  it('parses [0x90, 60, 100] as noteOn ch0 note60 vel100', () => {
+    const msg = parseMidiMessage([0x90, 60, 100]);
+    expect(msg.type).toBe('noteOn');
+    if (msg.type !== 'noteOn') throw new Error('narrowing');
+    expect(msg.channel).toBe(0);
+    expect(msg.note).toBe(60);
+    expect(msg.velocity).toBe(100);
+  });
+
+  it('parses Note-On on channel 3 correctly', () => {
+    const msg = parseMidiMessage([0x93, 48, 80]);
+    expect(msg.type).toBe('noteOn');
+    if (msg.type !== 'noteOn') throw new Error('narrowing');
+    expect(msg.channel).toBe(3);
+    expect(msg.note).toBe(48);
+    expect(msg.velocity).toBe(80);
+  });
+
+  it('normalises Note-On velocity=0 to noteOff (MIDI running-status convention)', () => {
+    const msg = parseMidiMessage([0x90, 60, 0]);
+    expect(msg.type).toBe('noteOff');
+    if (msg.type !== 'noteOff') throw new Error('narrowing');
+    expect(msg.channel).toBe(0);
+    expect(msg.note).toBe(60);
+    expect(msg.velocity).toBe(0);
+  });
+
+  it('accepts Uint8Array input', () => {
+    const msg = parseMidiMessage(new Uint8Array([0x91, 64, 127]));
+    expect(msg.type).toBe('noteOn');
+    if (msg.type !== 'noteOn') throw new Error('narrowing');
+    expect(msg.channel).toBe(1);
+    expect(msg.note).toBe(64);
+    expect(msg.velocity).toBe(127);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMidiMessage — Note Off
+// ---------------------------------------------------------------------------
+
+describe('parseMidiMessage — Note Off', () => {
+  it('parses [0x80, 60, 64] as noteOff ch0 note60 vel64', () => {
+    const msg = parseMidiMessage([0x80, 60, 64]);
+    expect(msg.type).toBe('noteOff');
+    if (msg.type !== 'noteOff') throw new Error('narrowing');
+    expect(msg.channel).toBe(0);
+    expect(msg.note).toBe(60);
+    expect(msg.velocity).toBe(64);
+  });
+
+  it('parses Note-Off on channel 15', () => {
+    const msg = parseMidiMessage([0x8f, 60, 0]);
+    expect(msg.type).toBe('noteOff');
+    if (msg.type !== 'noteOff') throw new Error('narrowing');
+    expect(msg.channel).toBe(15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMidiMessage — Control Change
+// ---------------------------------------------------------------------------
+
+describe('parseMidiMessage — Control Change', () => {
+  it('parses [0xB0, 64, 127] as CC sustain on ch0', () => {
+    const msg = parseMidiMessage([0xb0, 64, 127]);
+    expect(msg.type).toBe('controlChange');
+    if (msg.type !== 'controlChange') throw new Error('narrowing');
+    expect(msg.channel).toBe(0);
+    expect(msg.controller).toBe(64);
+    expect(msg.value).toBe(127);
+  });
+
+  it('parses [0xB0, 64, 0] as CC sustain off ch0', () => {
+    const msg = parseMidiMessage([0xb0, 64, 0]);
+    expect(msg.type).toBe('controlChange');
+    if (msg.type !== 'controlChange') throw new Error('narrowing');
+    expect(msg.controller).toBe(64);
+    expect(msg.value).toBe(0);
+  });
+
+  it('parses a generic CC on channel 5', () => {
+    const msg = parseMidiMessage([0xb5, 7, 100]);
+    expect(msg.type).toBe('controlChange');
+    if (msg.type !== 'controlChange') throw new Error('narrowing');
+    expect(msg.channel).toBe(5);
+    expect(msg.controller).toBe(7);
+    expect(msg.value).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMidiMessage — Program Change
+// ---------------------------------------------------------------------------
+
+describe('parseMidiMessage — Program Change', () => {
+  it('parses [0xC0, 42] as programChange ch0 program42', () => {
+    const msg = parseMidiMessage([0xc0, 42]);
+    expect(msg.type).toBe('programChange');
+    if (msg.type !== 'programChange') throw new Error('narrowing');
+    expect(msg.channel).toBe(0);
+    expect(msg.program).toBe(42);
+  });
+
+  it('parses Program Change on channel 9 (drums)', () => {
+    const msg = parseMidiMessage([0xc9, 0]);
+    expect(msg.type).toBe('programChange');
+    if (msg.type !== 'programChange') throw new Error('narrowing');
+    expect(msg.channel).toBe(9);
+    expect(msg.program).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMidiMessage — Pitch Bend
+// ---------------------------------------------------------------------------
+
+describe('parseMidiMessage — Pitch Bend', () => {
+  it('parses [0xE0, 0x00, 0x40] as pitchBend centre (8192)', () => {
+    const msg = parseMidiMessage([0xe0, 0x00, 0x40]);
+    expect(msg.type).toBe('pitchBend');
+    if (msg.type !== 'pitchBend') throw new Error('narrowing');
+    expect(msg.channel).toBe(0);
+    // LSB=0x00, MSB=0x40 → (0x40 << 7) | 0x00 = 64*128 = 8192
+    expect(msg.value).toBe(8192);
+  });
+
+  it('parses full-down bend [0xE0, 0x00, 0x00] as value 0', () => {
+    const msg = parseMidiMessage([0xe0, 0x00, 0x00]);
+    expect(msg.type).toBe('pitchBend');
+    if (msg.type !== 'pitchBend') throw new Error('narrowing');
+    expect(msg.value).toBe(0);
+  });
+
+  it('parses full-up bend [0xE0, 0x7F, 0x7F] as value 16383', () => {
+    const msg = parseMidiMessage([0xe0, 0x7f, 0x7f]);
+    expect(msg.type).toBe('pitchBend');
+    if (msg.type !== 'pitchBend') throw new Error('narrowing');
+    // (0x7F << 7) | 0x7F = 127*128 + 127 = 16383
+    expect(msg.value).toBe(16383);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMidiMessage — Error cases
+// ---------------------------------------------------------------------------
+
+describe('parseMidiMessage — errors', () => {
+  it('throws TypeError for an empty array', () => {
+    expect(() => parseMidiMessage([])).toThrow(TypeError);
+  });
+
+  it('throws TypeError for an unrecognised status byte (e.g. 0xF0 SysEx)', () => {
+    expect(() => parseMidiMessage([0xf0, 0x00])).toThrow(TypeError);
+  });
+
+  it('throws TypeError when Note-On is too short (1 byte)', () => {
+    expect(() => parseMidiMessage([0x90])).toThrow(TypeError);
+  });
+
+  it('throws TypeError when Note-On is too short (2 bytes)', () => {
+    expect(() => parseMidiMessage([0x90, 60])).toThrow(TypeError);
+  });
+
+  it('throws TypeError when Note-Off is too short', () => {
+    expect(() => parseMidiMessage([0x80, 60])).toThrow(TypeError);
+  });
+
+  it('throws TypeError when Control Change is too short', () => {
+    expect(() => parseMidiMessage([0xb0, 64])).toThrow(TypeError);
+  });
+
+  it('throws TypeError when Program Change is too short (1 byte)', () => {
+    expect(() => parseMidiMessage([0xc0])).toThrow(TypeError);
+  });
+
+  it('throws TypeError when Pitch Bend is too short', () => {
+    expect(() => parseMidiMessage([0xe0, 0x00])).toThrow(TypeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('MIDI constants', () => {
+  it('SUSTAIN_CONTROLLER is 64', () => {
+    expect(SUSTAIN_CONTROLLER).toBe(64);
+  });
+
+  it('SUSTAIN_THRESHOLD is 64', () => {
+    expect(SUSTAIN_THRESHOLD).toBe(64);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// messageToNote
+// ---------------------------------------------------------------------------
+
+describe('messageToNote', () => {
+  it('converts a noteOn message to the correct Note', () => {
+    const msg = parseMidiMessage([0x90, 60, 100]);
+    const note = messageToNote(msg);
+    expect(note).not.toBeNull();
+    expect(note!.midi).toBe(60);
+    // MIDI 60 = C4 (middle C)
+    expect(note!.note).toBe('C');
+    expect(note!.octave).toBe(4);
+  });
+
+  it('converts a noteOff message to the correct Note', () => {
+    const msg = parseMidiMessage([0x80, 60, 64]);
+    const note = messageToNote(msg);
+    expect(note).not.toBeNull();
+    expect(note!.midi).toBe(60);
+  });
+
+  it('returns null for controlChange messages', () => {
+    const msg = parseMidiMessage([0xb0, 64, 127]);
+    expect(messageToNote(msg)).toBeNull();
+  });
+
+  it('returns null for programChange messages', () => {
+    const msg = parseMidiMessage([0xc0, 0]);
+    expect(messageToNote(msg)).toBeNull();
+  });
+
+  it('returns null for pitchBend messages', () => {
+    const msg = parseMidiMessage([0xe0, 0x00, 0x40]);
+    expect(messageToNote(msg)).toBeNull();
+  });
+
+  it('respects accidentalPreference: flats for MIDI 61 gives Db', () => {
+    const msg = parseMidiMessage([0x90, 61, 80]);
+    const noteFlat = messageToNote(msg, { accidentalPreference: 'flats' });
+    expect(noteFlat!.note).toBe('Db');
+  });
+
+  it('defaults to sharps for MIDI 61 gives C#', () => {
+    const msg = parseMidiMessage([0x90, 61, 80]);
+    const noteSharp = messageToNote(msg);
+    expect(noteSharp!.note).toBe('C#');
+  });
+
+  it('converts Note-On vel=0 (normalised to noteOff) to the correct note', () => {
+    const msg = parseMidiMessage([0x90, 60, 0]);
+    expect(msg.type).toBe('noteOff');
+    const note = messageToNote(msg);
+    expect(note!.midi).toBe(60);
+  });
+});

--- a/src/midi/parse.test.ts
+++ b/src/midi/parse.test.ts
@@ -197,6 +197,82 @@ describe('parseMidiMessage — errors', () => {
 });
 
 // ---------------------------------------------------------------------------
+// parseMidiMessage — byte range validation
+// ---------------------------------------------------------------------------
+
+describe('parseMidiMessage — byte range validation', () => {
+  // Pinned ground-truth regression guard: valid noteOn still works.
+  it('parseMidiMessage([0x90, 60, 100]) returns a valid noteOn (regression guard)', () => {
+    const msg = parseMidiMessage([0x90, 60, 100]);
+    expect(msg.type).toBe('noteOn');
+    if (msg.type !== 'noteOn') throw new Error('narrowing');
+    expect(msg.channel).toBe(0);
+    expect(msg.note).toBe(60);
+    expect(msg.velocity).toBe(100);
+  });
+
+  // Note number out of range
+  it('parseMidiMessage([0x90, 999, 100]) throws RangeError (note > 127)', () => {
+    expect(() => parseMidiMessage([0x90, 999, 100])).toThrow(RangeError);
+  });
+
+  // Velocity out of range
+  it('parseMidiMessage([0x90, 60, 200]) throws RangeError (velocity > 127)', () => {
+    expect(() => parseMidiMessage([0x90, 60, 200])).toThrow(RangeError);
+  });
+
+  // Non-integer note (fractional)
+  it('parseMidiMessage([0x90, 60.5, 100]) throws TypeError (non-integer note)', () => {
+    expect(() => parseMidiMessage([0x90, 60.5, 100])).toThrow(TypeError);
+  });
+
+  // Negative note
+  it('parseMidiMessage([0x90, -1, 100]) throws RangeError (negative note)', () => {
+    expect(() => parseMidiMessage([0x90, -1, 100])).toThrow(RangeError);
+  });
+
+  // CC controller out of range
+  it('parseMidiMessage([0xB0, 200, 0]) throws RangeError (controller > 127)', () => {
+    expect(() => parseMidiMessage([0xb0, 200, 0])).toThrow(RangeError);
+  });
+
+  // CC value out of range
+  it('parseMidiMessage([0xB0, 64, 200]) throws RangeError (CC value > 127)', () => {
+    expect(() => parseMidiMessage([0xb0, 64, 200])).toThrow(RangeError);
+  });
+
+  // Non-integer CC controller
+  it('parseMidiMessage([0xB0, 7.5, 100]) throws TypeError (non-integer controller)', () => {
+    expect(() => parseMidiMessage([0xb0, 7.5, 100])).toThrow(TypeError);
+  });
+
+  // Program number out of range
+  it('parseMidiMessage([0xC0, 200]) throws RangeError (program > 127)', () => {
+    expect(() => parseMidiMessage([0xc0, 200])).toThrow(RangeError);
+  });
+
+  // Pitch-bend LSB out of range
+  it('parseMidiMessage([0xE0, 200, 0]) throws RangeError (pitch-bend LSB > 127)', () => {
+    expect(() => parseMidiMessage([0xe0, 200, 0])).toThrow(RangeError);
+  });
+
+  // Pitch-bend MSB out of range
+  it('parseMidiMessage([0xE0, 0, 200]) throws RangeError (pitch-bend MSB > 127)', () => {
+    expect(() => parseMidiMessage([0xe0, 0, 200])).toThrow(RangeError);
+  });
+
+  // Note-Off note out of range
+  it('parseMidiMessage([0x80, 200, 64]) throws RangeError (noteOff note > 127)', () => {
+    expect(() => parseMidiMessage([0x80, 200, 64])).toThrow(RangeError);
+  });
+
+  // Note-Off velocity out of range
+  it('parseMidiMessage([0x80, 60, 200]) throws RangeError (noteOff velocity > 127)', () => {
+    expect(() => parseMidiMessage([0x80, 60, 200])).toThrow(RangeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 

--- a/src/midi/parse.ts
+++ b/src/midi/parse.ts
@@ -59,6 +59,26 @@ function requireLength(data: Uint8Array | readonly number[], minimum: number): v
   }
 }
 
+/**
+ * Validates that a byte is an integer within the given range.
+ *
+ * @param value The raw value to validate (may be undefined for out-of-bounds access).
+ * @param field Human-readable field name used in error messages.
+ * @param max The inclusive upper bound (0 is always the lower bound).
+ * @returns The validated value.
+ * @throws {TypeError} When `value` is not a number or not an integer.
+ * @throws {RangeError} When `value` is out of the range 0..`max`.
+ */
+function validateByte(value: number | undefined, field: string, max: number): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new TypeError(`${field} must be an integer in 0..${max}, received ${String(value)}.`);
+  }
+  if (value < 0 || value > max) {
+    throw new RangeError(`${field} must be an integer in 0..${max}, received ${value}.`);
+  }
+  return value;
+}
+
 // ---------------------------------------------------------------------------
 // parseMidiMessage
 // ---------------------------------------------------------------------------
@@ -79,30 +99,24 @@ function requireLength(data: Uint8Array | readonly number[], minimum: number): v
 export function parseMidiMessage(data: Uint8Array | readonly number[]): MidiMessage {
   requireLength(data, 1);
 
-  // Non-null assertions are safe: requireLength has already validated length.
-  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
-  const statusByte = data[0]!;
+  // Validate status byte range first (before masking), so out-of-range values
+  // are rejected before type/channel extraction.
+  const statusByte = validateByte(data[0], 'Status byte', 255);
   const type = statusByte & STATUS_TYPE_MASK;
   const channel = statusByte & STATUS_CHANNEL_MASK;
 
   if (type === STATUS_NOTE_OFF) {
     requireLength(data, 3);
-    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
-    const message: NoteOffMessage = {
-      type: 'noteOff',
-      channel,
-      note: data[1]!,
-      velocity: data[2]!,
-    };
+    const note = validateByte(data[1], 'Note number', 127);
+    const velocity = validateByte(data[2], 'Velocity', 127);
+    const message: NoteOffMessage = { type: 'noteOff', channel, note, velocity };
     return message;
   }
 
   if (type === STATUS_NOTE_ON) {
     requireLength(data, 3);
-    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
-    const note = data[1]!;
-    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
-    const velocity = data[2]!;
+    const note = validateByte(data[1], 'Note number', 127);
+    const velocity = validateByte(data[2], 'Velocity', 127);
 
     // Per MIDI spec: Note-On with velocity 0 is equivalent to Note-Off.
     if (velocity === 0) {
@@ -116,29 +130,23 @@ export function parseMidiMessage(data: Uint8Array | readonly number[]): MidiMess
 
   if (type === STATUS_CONTROL_CHANGE) {
     requireLength(data, 3);
-    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
-    const message: ControlChangeMessage = {
-      type: 'controlChange',
-      channel,
-      controller: data[1]!,
-      value: data[2]!,
-    };
+    const controller = validateByte(data[1], 'Controller number', 127);
+    const value = validateByte(data[2], 'Controller value', 127);
+    const message: ControlChangeMessage = { type: 'controlChange', channel, controller, value };
     return message;
   }
 
   if (type === STATUS_PROGRAM_CHANGE) {
     requireLength(data, 2);
-    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
-    const message: ProgramChangeMessage = { type: 'programChange', channel, program: data[1]! };
+    const program = validateByte(data[1], 'Program number', 127);
+    const message: ProgramChangeMessage = { type: 'programChange', channel, program };
     return message;
   }
 
   if (type === STATUS_PITCH_BEND) {
     requireLength(data, 3);
-    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
-    const lsb = data[1]!;
-    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
-    const msb = data[2]!;
+    const lsb = validateByte(data[1], 'Pitch-bend LSB', 127);
+    const msb = validateByte(data[2], 'Pitch-bend MSB', 127);
     // 14-bit little-endian: value = (msb << 7) | lsb, range 0..16383, centre 8192.
     const value = (msb << 7) | lsb;
     const message: PitchBendMessage = { type: 'pitchBend', channel, value };

--- a/src/midi/parse.ts
+++ b/src/midi/parse.ts
@@ -1,0 +1,152 @@
+/**
+ * Low-level MIDI byte parsing.
+ *
+ * {@link parseMidiMessage} decodes a raw status+data byte array into a typed
+ * {@link MidiMessage} discriminated union. The MIDI specification defines the
+ * status byte encoding:
+ *
+ *   high nibble  message type
+ *   0x80         Note Off
+ *   0x90         Note On  (velocity 0 is normalised to Note Off)
+ *   0xB0         Control Change
+ *   0xC0         Program Change
+ *   0xE0         Pitch Bend
+ *
+ *   low nibble   channel (0..15)
+ *
+ * Pitch-bend data is 14-bit little-endian (LSB first, MSB second), centred at
+ * 8192 (0 bend).
+ */
+
+import type {
+  MidiMessage,
+  NoteOnMessage,
+  NoteOffMessage,
+  ControlChangeMessage,
+  ProgramChangeMessage,
+  PitchBendMessage,
+} from './types.js';
+import { SUSTAIN_THRESHOLD, SUSTAIN_CONTROLLER } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Status byte constants
+// ---------------------------------------------------------------------------
+
+const STATUS_NOTE_OFF = 0x80;
+const STATUS_NOTE_ON = 0x90;
+const STATUS_CONTROL_CHANGE = 0xb0;
+const STATUS_PROGRAM_CHANGE = 0xc0;
+const STATUS_PITCH_BEND = 0xe0;
+const STATUS_TYPE_MASK = 0xf0;
+const STATUS_CHANNEL_MASK = 0x0f;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(data: Uint8Array | readonly number[]): string {
+  const hex = Array.from(data)
+    .map((b) => `0x${b.toString(16).toUpperCase().padStart(2, '0')}`)
+    .join(', ');
+  return `[${hex}]`;
+}
+
+function requireLength(data: Uint8Array | readonly number[], minimum: number): void {
+  if (data.length < minimum) {
+    throw new TypeError(
+      `MIDI message too short: expected at least ${minimum} bytes, received ${formatBytes(data)}.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseMidiMessage
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a raw MIDI status+data byte array into a typed {@link MidiMessage}.
+ *
+ * MIDI conventions applied:
+ * - A Note-On with velocity 0 is normalised to a {@link NoteOffMessage}.
+ * - Pitch-bend data is a 14-bit little-endian pair (LSB, MSB), centred at 8192.
+ * - Sustain pedal is CC 64; value >= 64 = on, value < 64 = off.
+ *
+ * @param data The raw MIDI bytes: `[statusByte, dataByte1, ...]`.
+ * @returns The parsed message.
+ * @throws {TypeError} When the message is too short, malformed, or the status
+ *   nibble is not one of the five recognised channel-voice types.
+ */
+export function parseMidiMessage(data: Uint8Array | readonly number[]): MidiMessage {
+  requireLength(data, 1);
+
+  // Non-null assertions are safe: requireLength has already validated length.
+  // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+  const statusByte = data[0]!;
+  const type = statusByte & STATUS_TYPE_MASK;
+  const channel = statusByte & STATUS_CHANNEL_MASK;
+
+  if (type === STATUS_NOTE_OFF) {
+    requireLength(data, 3);
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const message: NoteOffMessage = {
+      type: 'noteOff',
+      channel,
+      note: data[1]!,
+      velocity: data[2]!,
+    };
+    return message;
+  }
+
+  if (type === STATUS_NOTE_ON) {
+    requireLength(data, 3);
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const note = data[1]!;
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const velocity = data[2]!;
+
+    // Per MIDI spec: Note-On with velocity 0 is equivalent to Note-Off.
+    if (velocity === 0) {
+      const message: NoteOffMessage = { type: 'noteOff', channel, note, velocity: 0 };
+      return message;
+    }
+
+    const message: NoteOnMessage = { type: 'noteOn', channel, note, velocity };
+    return message;
+  }
+
+  if (type === STATUS_CONTROL_CHANGE) {
+    requireLength(data, 3);
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const message: ControlChangeMessage = {
+      type: 'controlChange',
+      channel,
+      controller: data[1]!,
+      value: data[2]!,
+    };
+    return message;
+  }
+
+  if (type === STATUS_PROGRAM_CHANGE) {
+    requireLength(data, 2);
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const message: ProgramChangeMessage = { type: 'programChange', channel, program: data[1]! };
+    return message;
+  }
+
+  if (type === STATUS_PITCH_BEND) {
+    requireLength(data, 3);
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const lsb = data[1]!;
+    // oxlint-disable-next-line typescript-eslint/no-non-null-assertion
+    const msb = data[2]!;
+    // 14-bit little-endian: value = (msb << 7) | lsb, range 0..16383, centre 8192.
+    const value = (msb << 7) | lsb;
+    const message: PitchBendMessage = { type: 'pitchBend', channel, value };
+    return message;
+  }
+
+  throw new TypeError(`Unrecognised MIDI status byte in message ${formatBytes(data)}.`);
+}
+
+// Re-export so callers only need to import from this file.
+export { SUSTAIN_CONTROLLER, SUSTAIN_THRESHOLD };

--- a/src/midi/sequence-converter.ts
+++ b/src/midi/sequence-converter.ts
@@ -78,11 +78,21 @@ function processEvent(
 
   if (event.type === 'note') {
     const velocity = event.velocity ?? defaultVelocity;
+    if (velocity === 0) {
+      throw new RangeError(
+        `Note event velocity must be 1..127 for MIDI conversion (0 is interpreted as note-off), received 0.`,
+      );
+    }
     return noteOnOff(event.note.midi, velocity, channel, event.startSeconds, endSeconds);
   }
 
   if (event.type === 'chord') {
     const velocity = event.velocity ?? defaultVelocity;
+    if (velocity === 0) {
+      throw new RangeError(
+        `Note event velocity must be 1..127 for MIDI conversion (0 is interpreted as note-off), received 0.`,
+      );
+    }
     const messages: TimedMidiMessage[] = [];
     for (const note of event.chord.notes) {
       const pairs = noteOnOff(note.midi, velocity, channel, event.startSeconds, endSeconds);
@@ -97,24 +107,42 @@ function processEvent(
   return [];
 }
 
+function validateChannel(channel: number): void {
+  if (!Number.isInteger(channel) || channel < 0 || channel > 15) {
+    throw new RangeError(`channel must be an integer in 0..15, received ${channel}.`);
+  }
+}
+
+function validateDefaultVelocity(velocity: number): void {
+  if (!Number.isInteger(velocity) || velocity < 1 || velocity > 127) {
+    throw new RangeError(`defaultVelocity must be an integer in 1..127, received ${velocity}.`);
+  }
+}
+
 /**
- * Converts an octavian {@link Sequence} into an array of timed MIDI messages.
+ * Validates options and returns resolved channel and defaultVelocity.
  *
- * Each note and chord event yields Note-On and Note-Off message pairs.
- * Rest events are silently skipped. The result is sorted by `timeSeconds`
- * ascending; ties preserve the note-on-before-note-off ordering within
- * a single event.
- *
- * @param sequence The sequence to convert.
- * @param options Channel and default velocity overrides.
- * @returns Sorted array of timed MIDI messages.
+ * @throws {RangeError} When channel is not an integer in 0..15.
+ * @throws {RangeError} When defaultVelocity is not an integer in 1..127.
  */
+function validateSequenceToMidiOptions(options: SequenceToMidiMessagesOptions | undefined): {
+  readonly channel: number;
+  readonly defaultVelocity: number;
+} {
+  const channel = options?.channel ?? 0;
+  const defaultVelocity = options?.defaultVelocity ?? 64;
+
+  if (options?.channel !== undefined) validateChannel(channel);
+  if (options?.defaultVelocity !== undefined) validateDefaultVelocity(defaultVelocity);
+
+  return { channel, defaultVelocity };
+}
+
 export function sequenceToMidiMessages(
   sequence: Sequence,
   options?: SequenceToMidiMessagesOptions,
 ): readonly TimedMidiMessage[] {
-  const channel = options?.channel ?? 0;
-  const defaultVelocity = options?.defaultVelocity ?? 64;
+  const { channel, defaultVelocity } = validateSequenceToMidiOptions(options);
 
   const timedEvents = sequence.toAbsoluteSeconds();
   const result: TimedMidiMessage[] = [];

--- a/src/midi/sequence-converter.ts
+++ b/src/midi/sequence-converter.ts
@@ -1,0 +1,130 @@
+/**
+ * Converts an octavian {@link Sequence} into timed MIDI messages.
+ *
+ * {@link sequenceToMidiMessages} uses `Sequence.toAbsoluteSeconds()` to
+ * convert musical time to real time, then emits Note-On and Note-Off pairs
+ * for every Note and Chord event. Rest events produce no messages.
+ *
+ * The output is a flat array sorted by `timeSeconds` ascending. Simultaneous
+ * events (same `timeSeconds`) preserve the input order (Note-On before
+ * Note-Off when they coincide).
+ */
+
+import type { MidiMessage } from './types.js';
+import type { Sequence } from '../sequences/sequence.js';
+import type { TimedMusicEvent } from '../sequences/types.js';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link sequenceToMidiMessages}.
+ */
+export type SequenceToMidiMessagesOptions = {
+  /**
+   * Default MIDI channel for all emitted messages (0..15). Defaults to `0`.
+   */
+  readonly channel?: number;
+
+  /**
+   * Default velocity for events that carry no explicit velocity. Defaults to `64`.
+   */
+  readonly defaultVelocity?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Output type
+// ---------------------------------------------------------------------------
+
+/**
+ * A MIDI message paired with its absolute time in seconds.
+ */
+export type TimedMidiMessage = {
+  /** The MIDI message. */
+  readonly message: MidiMessage;
+  /** Absolute offset from the sequence start, in seconds. */
+  readonly timeSeconds: number;
+};
+
+// ---------------------------------------------------------------------------
+// sequenceToMidiMessages
+// ---------------------------------------------------------------------------
+
+function noteOnOff(
+  noteNumber: number,
+  velocity: number,
+  channel: number,
+  startSeconds: number,
+  endSeconds: number,
+): readonly TimedMidiMessage[] {
+  const on: TimedMidiMessage = {
+    message: { type: 'noteOn', channel, note: noteNumber, velocity },
+    timeSeconds: startSeconds,
+  };
+  const off: TimedMidiMessage = {
+    message: { type: 'noteOff', channel, note: noteNumber, velocity: 0 },
+    timeSeconds: endSeconds,
+  };
+  return [on, off];
+}
+
+function processEvent(
+  event: TimedMusicEvent,
+  channel: number,
+  defaultVelocity: number,
+): readonly TimedMidiMessage[] {
+  const endSeconds = event.startSeconds + event.durationSeconds;
+
+  if (event.type === 'note') {
+    const velocity = event.velocity ?? defaultVelocity;
+    return noteOnOff(event.note.midi, velocity, channel, event.startSeconds, endSeconds);
+  }
+
+  if (event.type === 'chord') {
+    const velocity = event.velocity ?? defaultVelocity;
+    const messages: TimedMidiMessage[] = [];
+    for (const note of event.chord.notes) {
+      const pairs = noteOnOff(note.midi, velocity, channel, event.startSeconds, endSeconds);
+      for (const pair of pairs) {
+        messages.push(pair);
+      }
+    }
+    return messages;
+  }
+
+  // Rest: no MIDI messages.
+  return [];
+}
+
+/**
+ * Converts an octavian {@link Sequence} into an array of timed MIDI messages.
+ *
+ * Each note and chord event yields Note-On and Note-Off message pairs.
+ * Rest events are silently skipped. The result is sorted by `timeSeconds`
+ * ascending; ties preserve the note-on-before-note-off ordering within
+ * a single event.
+ *
+ * @param sequence The sequence to convert.
+ * @param options Channel and default velocity overrides.
+ * @returns Sorted array of timed MIDI messages.
+ */
+export function sequenceToMidiMessages(
+  sequence: Sequence,
+  options?: SequenceToMidiMessagesOptions,
+): readonly TimedMidiMessage[] {
+  const channel = options?.channel ?? 0;
+  const defaultVelocity = options?.defaultVelocity ?? 64;
+
+  const timedEvents = sequence.toAbsoluteSeconds();
+  const result: TimedMidiMessage[] = [];
+
+  for (const event of timedEvents) {
+    const messages = processEvent(event, channel, defaultVelocity);
+    for (const msg of messages) {
+      result.push(msg);
+    }
+  }
+
+  return Object.freeze(result.toSorted((a, b) => a.timeSeconds - b.timeSeconds));
+}

--- a/src/midi/state.test.ts
+++ b/src/midi/state.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Tests for the active-note state model and sequence converter.
+ *
+ * Ground truth values are asserted against MIDI specification byte values and
+ * known music-theory relationships, not self-consistent recomputations.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { Note } from '../note.js';
+import { Chord } from '../chord.js';
+import { Sequence, musicalTime } from '../sequences/sequence.js';
+import {
+  createMidiState,
+  applyMidiMessage,
+  notesFromActiveMidiState,
+  chordFromActiveMidiState,
+} from './state.js';
+import { sequenceToMidiMessages } from './sequence-converter.js';
+import { parseMidiMessage } from './parse.js';
+
+// ---------------------------------------------------------------------------
+// createMidiState
+// ---------------------------------------------------------------------------
+
+describe('createMidiState', () => {
+  it('returns an empty initial state', () => {
+    const state = createMidiState();
+    expect(state.heldNotes.size).toBe(0);
+    expect(state.sustainedNotes.size).toBe(0);
+    expect(state.sustainOn).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyMidiMessage — basic noteOn / noteOff
+// ---------------------------------------------------------------------------
+
+describe('applyMidiMessage — basic note on/off', () => {
+  it('adds a note to heldNotes on noteOn', () => {
+    const state = applyMidiMessage(createMidiState(), parseMidiMessage([0x90, 60, 100]));
+    expect(state.heldNotes.has(60)).toBe(true);
+  });
+
+  it('removes a note from heldNotes on noteOff', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x80, 60, 64]));
+    expect(state.heldNotes.has(60)).toBe(false);
+  });
+
+  it('Note-On vel=0 removes note like a noteOff', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 0]));
+    expect(state.heldNotes.has(60)).toBe(false);
+  });
+
+  it('holds multiple notes simultaneously', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 64, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 67, 100]));
+    expect(state.heldNotes.has(60)).toBe(true);
+    expect(state.heldNotes.has(64)).toBe(true);
+    expect(state.heldNotes.has(67)).toBe(true);
+  });
+
+  it('does not affect sustainedNotes when releasing without sustain', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x80, 60, 0]));
+    expect(state.sustainedNotes.size).toBe(0);
+  });
+
+  it('leaves state unchanged for non-note messages (pitch bend)', () => {
+    const initial = createMidiState();
+    const state = applyMidiMessage(initial, parseMidiMessage([0xe0, 0x00, 0x40]));
+    expect(state).toBe(initial);
+  });
+
+  it('leaves state unchanged for non-note messages (program change)', () => {
+    const initial = createMidiState();
+    const state = applyMidiMessage(initial, parseMidiMessage([0xc0, 5]));
+    expect(state).toBe(initial);
+  });
+
+  it('leaves state unchanged for non-sustain CC', () => {
+    const initial = createMidiState();
+    const state = applyMidiMessage(initial, parseMidiMessage([0xb0, 7, 100]));
+    expect(state).toBe(initial);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyMidiMessage — sustain pedal (CC 64)
+// ---------------------------------------------------------------------------
+
+describe('applyMidiMessage — sustain pedal', () => {
+  it('sets sustainOn when CC64 value >= 64', () => {
+    const state = applyMidiMessage(createMidiState(), parseMidiMessage([0xb0, 64, 127]));
+    expect(state.sustainOn).toBe(true);
+  });
+
+  it('sets sustainOn at exactly the threshold (64)', () => {
+    const state = applyMidiMessage(createMidiState(), parseMidiMessage([0xb0, 64, 64]));
+    expect(state.sustainOn).toBe(true);
+  });
+
+  it('does not set sustainOn when CC64 value < 64', () => {
+    const state = applyMidiMessage(createMidiState(), parseMidiMessage([0xb0, 64, 63]));
+    expect(state.sustainOn).toBe(false);
+  });
+
+  it('clears sustainedNotes when sustain is released', () => {
+    let state = createMidiState();
+    // Press note, engage sustain, release note → note moves to sustainedNotes.
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0xb0, 64, 127]));
+    state = applyMidiMessage(state, parseMidiMessage([0x80, 60, 0]));
+    expect(state.sustainedNotes.has(60)).toBe(true);
+    // Release sustain → sustainedNotes cleared.
+    state = applyMidiMessage(state, parseMidiMessage([0xb0, 64, 0]));
+    expect(state.sustainedNotes.size).toBe(0);
+    expect(state.sustainOn).toBe(false);
+  });
+
+  it('noteOn then sustain-on then noteOff keeps note in sustainedNotes until pedal lift', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0xb0, 64, 127]));
+    state = applyMidiMessage(state, parseMidiMessage([0x80, 60, 0]));
+    // Note should still be "sounding" via sustain.
+    expect(state.heldNotes.has(60)).toBe(false);
+    expect(state.sustainedNotes.has(60)).toBe(true);
+  });
+
+  it('re-striking a sustained note removes it from sustainedNotes', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0xb0, 64, 127]));
+    state = applyMidiMessage(state, parseMidiMessage([0x80, 60, 0]));
+    // Re-strike note.
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 80]));
+    expect(state.heldNotes.has(60)).toBe(true);
+    expect(state.sustainedNotes.has(60)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// notesFromActiveMidiState
+// ---------------------------------------------------------------------------
+
+describe('notesFromActiveMidiState', () => {
+  it('returns empty array when no notes are sounding', () => {
+    expect(notesFromActiveMidiState(createMidiState())).toHaveLength(0);
+  });
+
+  it('returns held notes sorted by MIDI number ascending', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 67, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 64, 100]));
+    const notes = notesFromActiveMidiState(state);
+    expect(notes).toHaveLength(3);
+    expect(notes[0]!.midi).toBe(60);
+    expect(notes[1]!.midi).toBe(64);
+    expect(notes[2]!.midi).toBe(67);
+  });
+
+  it('includes sustained notes', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0xb0, 64, 127]));
+    state = applyMidiMessage(state, parseMidiMessage([0x80, 60, 0]));
+    const notes = notesFromActiveMidiState(state);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]!.midi).toBe(60);
+  });
+
+  it('deduplicates notes that are both held and sustained', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0xb0, 64, 127]));
+    // Note 60 is held. It should appear once.
+    const notes = notesFromActiveMidiState(state);
+    expect(notes).toHaveLength(1);
+  });
+
+  it('respects accidentalPreference flats', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 61, 100]));
+    const notesFlat = notesFromActiveMidiState(state, { accidentalPreference: 'flats' });
+    expect(notesFlat[0]!.note).toBe('Db');
+    const notesSharp = notesFromActiveMidiState(state, { accidentalPreference: 'sharps' });
+    expect(notesSharp[0]!.note).toBe('C#');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chordFromActiveMidiState
+// ---------------------------------------------------------------------------
+
+describe('chordFromActiveMidiState', () => {
+  it('returns null when no notes are sounding', () => {
+    expect(chordFromActiveMidiState(createMidiState())).toBeNull();
+  });
+
+  it('returns null when only one note is sounding', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    expect(chordFromActiveMidiState(state)).toBeNull();
+  });
+
+  it('identifies C major (MIDI 60, 64, 67) as a major chord rooted on C', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100])); // C4
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 64, 100])); // E4
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 67, 100])); // G4
+    const chord = chordFromActiveMidiState(state);
+    expect(chord).not.toBeNull();
+    expect(chord!.root.note).toBe('C');
+    expect(chord!.suffix).toBe('major');
+  });
+
+  it('identifies A minor (MIDI 57, 60, 64) as a minor chord rooted on A', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 57, 100])); // A3
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100])); // C4
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 64, 100])); // E4
+    const chord = chordFromActiveMidiState(state);
+    expect(chord).not.toBeNull();
+    expect(chord!.root.note).toBe('A');
+    expect(chord!.suffix).toBe('minor');
+  });
+
+  it('returns null for two notes that do not form a recognisable chord', () => {
+    let state = createMidiState();
+    // Tritone — not a catalogued chord.
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 66, 100]));
+    expect(chordFromActiveMidiState(state)).toBeNull();
+  });
+
+  it('chord capture survives sustain: hold C-E-G, sustain on, release all → C major still detected', () => {
+    let state = createMidiState();
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 60, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 64, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0x90, 67, 100]));
+    state = applyMidiMessage(state, parseMidiMessage([0xb0, 64, 127]));
+    state = applyMidiMessage(state, parseMidiMessage([0x80, 60, 0]));
+    state = applyMidiMessage(state, parseMidiMessage([0x80, 64, 0]));
+    state = applyMidiMessage(state, parseMidiMessage([0x80, 67, 0]));
+    const chord = chordFromActiveMidiState(state);
+    expect(chord).not.toBeNull();
+    expect(chord!.suffix).toBe('major');
+    // Lift sustain — chord should disappear.
+    state = applyMidiMessage(state, parseMidiMessage([0xb0, 64, 0]));
+    expect(chordFromActiveMidiState(state)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sequenceToMidiMessages
+// ---------------------------------------------------------------------------
+
+describe('sequenceToMidiMessages', () => {
+  it('produces note-on and note-off for a single note event', () => {
+    const note = Note.fromMidi(60);
+    const seq = Sequence.create(
+      [{ type: 'note', note, start: musicalTime(0, 1), duration: musicalTime(1, 4), velocity: 80 }],
+      { tempo: 120 },
+    );
+    const messages = sequenceToMidiMessages(seq);
+    // At 120 BPM, quarter note = 0.5 s.
+    const noteOns = messages.filter((m) => m.message.type === 'noteOn');
+    const noteOffs = messages.filter((m) => m.message.type === 'noteOff');
+    expect(noteOns).toHaveLength(1);
+    expect(noteOffs).toHaveLength(1);
+    expect(noteOns[0]!.message.type).toBe('noteOn');
+    if (noteOns[0]!.message.type === 'noteOn') {
+      expect(noteOns[0]!.message.note).toBe(60);
+      expect(noteOns[0]!.message.velocity).toBe(80);
+    }
+    expect(noteOns[0]!.timeSeconds).toBeCloseTo(0);
+    expect(noteOffs[0]!.timeSeconds).toBeCloseTo(0.5);
+  });
+
+  it('uses default velocity 64 when event has no velocity', () => {
+    const note = Note.fromMidi(60);
+    const seq = Sequence.create(
+      [{ type: 'note', note, start: musicalTime(0, 1), duration: musicalTime(1, 4) }],
+      { tempo: 120 },
+    );
+    const messages = sequenceToMidiMessages(seq);
+    const noteOn = messages.find((m) => m.message.type === 'noteOn');
+    expect(noteOn).toBeDefined();
+    if (noteOn?.message.type === 'noteOn') {
+      expect(noteOn.message.velocity).toBe(64);
+    }
+  });
+
+  it('uses provided defaultVelocity option', () => {
+    const note = Note.fromMidi(60);
+    const seq = Sequence.create(
+      [{ type: 'note', note, start: musicalTime(0, 1), duration: musicalTime(1, 4) }],
+      { tempo: 120 },
+    );
+    const messages = sequenceToMidiMessages(seq, { defaultVelocity: 100 });
+    const noteOn = messages.find((m) => m.message.type === 'noteOn');
+    if (noteOn?.message.type === 'noteOn') {
+      expect(noteOn.message.velocity).toBe(100);
+    }
+  });
+
+  it('uses the provided channel option', () => {
+    const note = Note.fromMidi(60);
+    const seq = Sequence.create(
+      [{ type: 'note', note, start: musicalTime(0, 1), duration: musicalTime(1, 4) }],
+      { tempo: 120 },
+    );
+    const messages = sequenceToMidiMessages(seq, { channel: 9 });
+    for (const { message } of messages) {
+      expect(message.channel).toBe(9);
+    }
+  });
+
+  it('skips rest events', () => {
+    const seq = Sequence.create(
+      [{ type: 'rest', start: musicalTime(0, 1), duration: musicalTime(1, 4) }],
+      { tempo: 120 },
+    );
+    expect(sequenceToMidiMessages(seq)).toHaveLength(0);
+  });
+
+  it('expands chord events into per-note messages', () => {
+    const chord = Chord.create('C4', 'major');
+    const seq = Sequence.create(
+      [
+        {
+          type: 'chord',
+          chord,
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+          velocity: 90,
+        },
+      ],
+      { tempo: 120 },
+    );
+    const messages = sequenceToMidiMessages(seq);
+    const noteOns = messages.filter((m) => m.message.type === 'noteOn');
+    // C major triad has 3 notes.
+    expect(noteOns).toHaveLength(3);
+  });
+
+  it('returns messages sorted by timeSeconds ascending', () => {
+    const noteA = Note.fromMidi(60);
+    const noteB = Note.fromMidi(62);
+    const seq = Sequence.create(
+      [
+        { type: 'note', note: noteB, start: musicalTime(1, 4), duration: musicalTime(1, 4) },
+        { type: 'note', note: noteA, start: musicalTime(0, 1), duration: musicalTime(1, 4) },
+      ],
+      { tempo: 120 },
+    );
+    const messages = sequenceToMidiMessages(seq);
+    for (let i = 1; i < messages.length; i += 1) {
+      expect(messages[i]!.timeSeconds).toBeGreaterThanOrEqual(messages[i - 1]!.timeSeconds);
+    }
+  });
+
+  it('returns frozen array', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    const messages = sequenceToMidiMessages(seq);
+    expect(Object.isFrozen(messages)).toBe(true);
+  });
+});

--- a/src/midi/state.test.ts
+++ b/src/midi/state.test.ts
@@ -373,4 +373,82 @@ describe('sequenceToMidiMessages', () => {
     const messages = sequenceToMidiMessages(seq);
     expect(Object.isFrozen(messages)).toBe(true);
   });
+
+  // Fix #3: option validation
+  it('throws RangeError for channel 16', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    expect(() => sequenceToMidiMessages(seq, { channel: 16 })).toThrow(RangeError);
+    expect(() => sequenceToMidiMessages(seq, { channel: 16 })).toThrow(/0..15/);
+  });
+
+  it('throws RangeError for channel -1', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    expect(() => sequenceToMidiMessages(seq, { channel: -1 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for defaultVelocity 0', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    expect(() => sequenceToMidiMessages(seq, { defaultVelocity: 0 })).toThrow(RangeError);
+    expect(() => sequenceToMidiMessages(seq, { defaultVelocity: 0 })).toThrow(/1..127/);
+  });
+
+  it('throws RangeError for defaultVelocity 200', () => {
+    const seq = Sequence.create([], { tempo: 120 });
+    expect(() => sequenceToMidiMessages(seq, { defaultVelocity: 200 })).toThrow(RangeError);
+  });
+
+  // Fix #4: velocity-0 rejection at MIDI conversion boundary
+  it('throws RangeError when a note event has velocity 0', () => {
+    const note = Note.fromMidi(60);
+    const seq = Sequence.create(
+      [{ type: 'note', note, start: musicalTime(0, 1), duration: musicalTime(1, 4), velocity: 0 }],
+      { tempo: 120 },
+    );
+    expect(() => sequenceToMidiMessages(seq)).toThrow(RangeError);
+    expect(() => sequenceToMidiMessages(seq)).toThrow(/0 is interpreted as note-off/);
+  });
+
+  it('throws RangeError when a chord event has velocity 0', () => {
+    const chord = Chord.create('C4', 'major');
+    const seq = Sequence.create(
+      [
+        {
+          type: 'chord',
+          chord,
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+          velocity: 0,
+        },
+      ],
+      { tempo: 120 },
+    );
+    expect(() => sequenceToMidiMessages(seq)).toThrow(RangeError);
+    expect(() => sequenceToMidiMessages(seq)).toThrow(/0 is interpreted as note-off/);
+  });
+
+  it('accepts note event velocity 1 (boundary)', () => {
+    const note = Note.fromMidi(60);
+    const seq = Sequence.create(
+      [{ type: 'note', note, start: musicalTime(0, 1), duration: musicalTime(1, 4), velocity: 1 }],
+      { tempo: 120 },
+    );
+    expect(() => sequenceToMidiMessages(seq)).not.toThrow();
+  });
+
+  it('accepts note event velocity 127 (boundary)', () => {
+    const note = Note.fromMidi(60);
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note,
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+          velocity: 127,
+        },
+      ],
+      { tempo: 120 },
+    );
+    expect(() => sequenceToMidiMessages(seq)).not.toThrow();
+  });
 });

--- a/src/midi/state.ts
+++ b/src/midi/state.ts
@@ -1,0 +1,229 @@
+/**
+ * Pure MIDI active-note state model.
+ *
+ * {@link applyMidiMessage} is a pure reducer: given the current state and an
+ * incoming message it returns a new state object (no mutation). The state
+ * tracks:
+ *
+ *  - Which notes are actively held by the performer (`heldNotes`).
+ *  - Whether the sustain pedal (CC 64) is on (`sustainOn`).
+ *  - Which notes are sustaining but no longer physically held
+ *    (`sustainedNotes`): notes released while sustain is down remain
+ *    "sounding" until sustain lifts.
+ *
+ * The "sounding" set (what you actually hear) = heldNotes ∪ sustainedNotes.
+ * When the sustain pedal is lifted, sustainedNotes is cleared.
+ */
+
+import { Note } from '../note.js';
+import { Chord } from '../chord.js';
+import { findChordSuffixByIntervals } from '../chords.js';
+import type { AccidentalPreference } from '../key-signatures.js';
+import type { MidiMessage } from './types.js';
+import { SUSTAIN_CONTROLLER, SUSTAIN_THRESHOLD } from './types.js';
+
+// ---------------------------------------------------------------------------
+// MidiState
+// ---------------------------------------------------------------------------
+
+/**
+ * Immutable snapshot of the active-note state for one MIDI channel.
+ *
+ * Build an initial state with {@link createMidiState} and advance it with
+ * {@link applyMidiMessage}.
+ */
+export type MidiState = {
+  /**
+   * MIDI note numbers (0..127) that are currently physically held down.
+   * Represented as a `ReadonlySet` for O(1) membership tests.
+   */
+  readonly heldNotes: ReadonlySet<number>;
+
+  /**
+   * MIDI note numbers that were released while the sustain pedal was down.
+   * These notes continue sounding until the pedal is lifted.
+   */
+  readonly sustainedNotes: ReadonlySet<number>;
+
+  /**
+   * `true` when CC 64 (sustain pedal) is currently on (value >= 64).
+   */
+  readonly sustainOn: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// createMidiState
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an empty initial {@link MidiState} with no held notes and sustain off.
+ *
+ * @returns A fresh MIDI state.
+ */
+export function createMidiState(): MidiState {
+  return {
+    heldNotes: new Set(),
+    sustainedNotes: new Set(),
+    sustainOn: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// applyMidiMessage
+// ---------------------------------------------------------------------------
+
+function applyNoteOn(state: MidiState, noteNumber: number): MidiState {
+  const heldNotes = new Set(state.heldNotes);
+  heldNotes.add(noteNumber);
+
+  // Also remove from sustainedNotes (re-striking a sustained note resets it).
+  const sustainedNotes = new Set(state.sustainedNotes);
+  sustainedNotes.delete(noteNumber);
+
+  return { heldNotes, sustainedNotes, sustainOn: state.sustainOn };
+}
+
+function applyNoteOff(state: MidiState, noteNumber: number): MidiState {
+  const heldNotes = new Set(state.heldNotes);
+  heldNotes.delete(noteNumber);
+
+  if (state.sustainOn) {
+    // Sustain is on: move to sustained set rather than removing from sounding.
+    const sustainedNotes = new Set(state.sustainedNotes);
+    sustainedNotes.add(noteNumber);
+    return { heldNotes, sustainedNotes, sustainOn: true };
+  }
+
+  return { heldNotes, sustainedNotes: state.sustainedNotes, sustainOn: false };
+}
+
+function applySustainOn(state: MidiState): MidiState {
+  return { heldNotes: state.heldNotes, sustainedNotes: state.sustainedNotes, sustainOn: true };
+}
+
+function applySustainOff(state: MidiState): MidiState {
+  // Lift pedal: all sustained-but-released notes stop sounding.
+  return { heldNotes: state.heldNotes, sustainedNotes: new Set(), sustainOn: false };
+}
+
+/**
+ * Pure reducer: returns a new {@link MidiState} after applying `message`.
+ *
+ * Note-On adds to `heldNotes`; Note-Off (or Note-On velocity=0) removes from
+ * `heldNotes`, moving the note to `sustainedNotes` if the sustain pedal is
+ * currently on. When CC 64 goes below the sustain threshold, `sustainedNotes`
+ * is cleared. All other message types leave the state unchanged.
+ *
+ * @param state The current state.
+ * @param message The MIDI message to apply.
+ * @returns A new state (the input is never mutated).
+ */
+export function applyMidiMessage(state: MidiState, message: MidiMessage): MidiState {
+  if (message.type === 'noteOn') {
+    return applyNoteOn(state, message.note);
+  }
+
+  if (message.type === 'noteOff') {
+    return applyNoteOff(state, message.note);
+  }
+
+  if (message.type === 'controlChange' && message.controller === SUSTAIN_CONTROLLER) {
+    if (message.value >= SUSTAIN_THRESHOLD) {
+      return applySustainOn(state);
+    }
+    return applySustainOff(state);
+  }
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// notesFromActiveMidiState
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for note-query helpers.
+ */
+export type ActiveMidiStateOptions = {
+  /**
+   * Whether to prefer sharps or flats when spelling notes.
+   * Defaults to `'sharps'`.
+   */
+  readonly accidentalPreference?: AccidentalPreference;
+};
+
+/**
+ * Returns every currently-sounding {@link Note} from the given MIDI state.
+ *
+ * "Sounding" includes both held notes and notes that are being sustained
+ * by the sustain pedal. The result is sorted by MIDI note number ascending.
+ *
+ * @param state The current MIDI state.
+ * @param options Spelling preference for accidentals.
+ * @returns A sorted, frozen array of sounding notes.
+ */
+export function notesFromActiveMidiState(
+  state: MidiState,
+  options?: ActiveMidiStateOptions,
+): readonly Note[] {
+  const preference = options?.accidentalPreference ?? 'sharps';
+
+  const allNoteNumbers = new Set([...state.heldNotes, ...state.sustainedNotes]);
+  const sorted = [...allNoteNumbers].toSorted((a, b) => a - b);
+
+  return Object.freeze(sorted.map((n) => Note.fromMidi(n, preference)));
+}
+
+// ---------------------------------------------------------------------------
+// chordFromActiveMidiState
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempts to identify a chord from the currently-sounding notes.
+ *
+ * The lowest sounding note (by MIDI number) is used as the root candidate.
+ * Intervals from that root to each other sounding note are computed and
+ * matched against the chord catalog. Returns `null` when fewer than 2 notes
+ * are sounding or the pitch-class set does not match a known chord.
+ *
+ * @param state The current MIDI state.
+ * @param options Spelling preference for accidentals.
+ * @returns The identified chord, or `null`.
+ */
+export function chordFromActiveMidiState(
+  state: MidiState,
+  options?: ActiveMidiStateOptions,
+): Chord | null {
+  const notes = notesFromActiveMidiState(state, options);
+
+  if (notes.length < 2) {
+    return null;
+  }
+
+  // Deduplicate by pitch class (chromatic index) to avoid octave duplicates
+  // confusing interval calculation, then sort ascending.
+  const seen = new Set<number>();
+  const deduped: Note[] = [];
+  for (const note of notes) {
+    if (!seen.has(note.chromaticIndex)) {
+      seen.add(note.chromaticIndex);
+      deduped.push(note);
+    }
+  }
+
+  if (deduped.length < 2) return null;
+
+  const dedupedRoot = deduped[0];
+  if (!dedupedRoot) return null;
+
+  // Map every note (including root) to its distance from the root; root gives 'perfectUnison'.
+  // This matches the convention in the chord catalog where intervals[0] = 'perfectUnison'.
+  const intervals = deduped.map((note) => dedupedRoot.distanceTo(note));
+  const suffix = findChordSuffixByIntervals(intervals);
+
+  if (!suffix) {
+    return null;
+  }
+
+  return Chord.create(dedupedRoot, suffix);
+}

--- a/src/midi/types.ts
+++ b/src/midi/types.ts
@@ -1,0 +1,114 @@
+/**
+ * Discriminated-union types for MIDI messages.
+ *
+ * Each variant carries the raw `channel` (0..15) and type-specific fields.
+ * The `type` discriminant matches the MIDI status byte's high nibble:
+ *   - `'noteOff'`         0x80
+ *   - `'noteOn'`          0x90 (velocity=0 normalises to noteOff)
+ *   - `'controlChange'`   0xB0
+ *   - `'programChange'`   0xC0
+ *   - `'pitchBend'`       0xE0
+ */
+
+// ---------------------------------------------------------------------------
+// Individual message variants
+// ---------------------------------------------------------------------------
+
+/**
+ * A MIDI Note-Off message (status nibble 0x80), or a Note-On with velocity 0
+ * that has been normalised to note-off per the MIDI specification.
+ */
+export type NoteOffMessage = {
+  /** Discriminant. */
+  readonly type: 'noteOff';
+  /** MIDI channel, 0..15. */
+  readonly channel: number;
+  /** MIDI note number, 0..127. */
+  readonly note: number;
+  /** Release velocity, 0..127. */
+  readonly velocity: number;
+};
+
+/**
+ * A MIDI Note-On message (status nibble 0x90) with a non-zero velocity.
+ * A Note-On with velocity 0 is parsed as {@link NoteOffMessage}.
+ */
+export type NoteOnMessage = {
+  /** Discriminant. */
+  readonly type: 'noteOn';
+  /** MIDI channel, 0..15. */
+  readonly channel: number;
+  /** MIDI note number, 0..127. */
+  readonly note: number;
+  /** Attack velocity, 1..127. */
+  readonly velocity: number;
+};
+
+/**
+ * A MIDI Control Change message (status nibble 0xB0).
+ * CC 64 is the sustain pedal: value >= 64 = on, value < 64 = off.
+ */
+export type ControlChangeMessage = {
+  /** Discriminant. */
+  readonly type: 'controlChange';
+  /** MIDI channel, 0..15. */
+  readonly channel: number;
+  /** Controller number, 0..127. */
+  readonly controller: number;
+  /** Controller value, 0..127. */
+  readonly value: number;
+};
+
+/**
+ * A MIDI Program Change message (status nibble 0xC0).
+ */
+export type ProgramChangeMessage = {
+  /** Discriminant. */
+  readonly type: 'programChange';
+  /** MIDI channel, 0..15. */
+  readonly channel: number;
+  /** Program number, 0..127. */
+  readonly program: number;
+};
+
+/**
+ * A MIDI Pitch Bend message (status nibble 0xE0).
+ * The 14-bit value is transmitted as two 7-bit bytes (LSB first, MSB second)
+ * and ranges 0..16383, centred at 8192 (no bend).
+ */
+export type PitchBendMessage = {
+  /** Discriminant. */
+  readonly type: 'pitchBend';
+  /** MIDI channel, 0..15. */
+  readonly channel: number;
+  /**
+   * The 14-bit bend value, 0..16383. Centre (no bend) = 8192.
+   * Positive values bend up; negative values bend down from centre.
+   */
+  readonly value: number;
+};
+
+// ---------------------------------------------------------------------------
+// Union
+// ---------------------------------------------------------------------------
+
+/**
+ * A parsed MIDI message — one of the five common channel-voice message types.
+ * Discriminate on the `type` field.
+ */
+export type MidiMessage =
+  | NoteOnMessage
+  | NoteOffMessage
+  | ControlChangeMessage
+  | ProgramChangeMessage
+  | PitchBendMessage;
+
+// ---------------------------------------------------------------------------
+// Sustain CC constant
+// ---------------------------------------------------------------------------
+
+/** MIDI controller number for the sustain pedal (damper). */
+export const SUSTAIN_CONTROLLER = 64 as const;
+
+/** Sustain pedal is on when its value is >= this threshold. */
+export const SUSTAIN_THRESHOLD = 64 as const;

--- a/src/midi/types.ts
+++ b/src/midi/types.ts
@@ -82,8 +82,8 @@ export type PitchBendMessage = {
   /** MIDI channel, 0..15. */
   readonly channel: number;
   /**
-   * The 14-bit bend value, 0..16383. Centre (no bend) = 8192.
-   * Positive values bend up; negative values bend down from centre.
+   * The raw unsigned 14-bit bend value, 0..16383. Centre (no bend) = 8192.
+   * Full bend down = 0; full bend up = 16383.
    */
   readonly value: number;
 };

--- a/src/notation/accidental-display.ts
+++ b/src/notation/accidental-display.ts
@@ -6,7 +6,7 @@
  * already implies the note's correct spelling — no symbol is drawn.
  */
 
-import { accidentalFromNoteName, naturalFromNoteName } from '../note-spellings.js';
+import { accidentalFromNoteName, naturalFromNoteName, type Accidental } from '../note-spellings.js';
 import { Note, type NoteLike } from '../note.js';
 import type { KeySignatureInformation } from '../key-signature-catalog.js';
 import type { AccidentalDisplay } from './types.js';
@@ -43,11 +43,13 @@ function keySignatureAccidentalFor(letter: string, keySignature: KeySignatureInf
 }
 
 /**
- * Maps an accidental suffix string to an {@link AccidentalDisplay} value.
+ * Maps an {@link Accidental} suffix to an {@link AccidentalDisplay} value.
  *
- * @throws {TypeError} When the suffix is not a supported accidental.
+ * The parameter is typed as {@link Accidental} (the exhaustive union from
+ * `note-spellings`), so the switch covers every possible value at compile
+ * time — no `default` branch is needed or present. // exhaustive
  */
-function accidentalSuffixToDisplay(suffix: string): AccidentalDisplay {
+function accidentalSuffixToDisplay(suffix: Accidental): AccidentalDisplay {
   switch (suffix) {
     case '#':
       return 'sharp';
@@ -63,8 +65,6 @@ function accidentalSuffixToDisplay(suffix: string): AccidentalDisplay {
       return 'triple-flat';
     case '':
       return 'natural';
-    default:
-      throw new TypeError(`Unsupported accidental suffix: ${suffix}.`);
   }
 }
 

--- a/src/notation/accidental-display.ts
+++ b/src/notation/accidental-display.ts
@@ -1,0 +1,108 @@
+/**
+ * Accidental display logic for notation rendering.
+ *
+ * Determines which accidental glyph (if any) a renderer must draw for a note
+ * given the active key signature.  A `null` result means the key signature
+ * already implies the note's correct spelling — no symbol is drawn.
+ */
+
+import { accidentalFromNoteName, naturalFromNoteName } from '../note-spellings.js';
+import { Note, type NoteLike } from '../note.js';
+import type { KeySignatureInformation } from '../key-signature-catalog.js';
+import type { AccidentalDisplay } from './types.js';
+
+// ---------------------------------------------------------------------------
+// C-major (no accidentals) singleton — used as the default key signature
+// ---------------------------------------------------------------------------
+
+/**
+ * The implied accidental for a natural note letter in the C-major key
+ * (i.e., no accidentals on any letter).
+ */
+const C_MAJOR_ACCIDENTAL_SUFFIX = '' as const;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the accidental suffix that the key signature implies for the given
+ * note letter, or `''` (natural) if the letter is not altered by the key.
+ *
+ * The key signature `accidentals` array contains entries like `'F#'`, `'Bb'`,
+ * `'F##'`, etc. We extract the letter and compare.
+ */
+function keySignatureAccidentalFor(letter: string, keySignature: KeySignatureInformation): string {
+  for (const keyNote of keySignature.accidentals) {
+    if (keyNote.startsWith(letter)) {
+      // Everything after the first character is the accidental suffix.
+      return keyNote.slice(1);
+    }
+  }
+  return C_MAJOR_ACCIDENTAL_SUFFIX;
+}
+
+/**
+ * Maps an accidental suffix string to an {@link AccidentalDisplay} value.
+ *
+ * @throws {TypeError} When the suffix is not a supported accidental.
+ */
+function accidentalSuffixToDisplay(suffix: string): AccidentalDisplay {
+  switch (suffix) {
+    case '#':
+      return 'sharp';
+    case 'b':
+      return 'flat';
+    case '##':
+      return 'double-sharp';
+    case 'bb':
+      return 'double-flat';
+    case '###':
+      return 'triple-sharp';
+    case 'bbb':
+      return 'triple-flat';
+    case '':
+      return 'natural';
+    default:
+      throw new TypeError(`Unsupported accidental suffix: ${suffix}.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the accidental glyph a renderer must draw for a note given the
+ * active key signature, or `null` when no accidental is needed.
+ *
+ * Rules:
+ * - When the note's accidental matches what the key signature implies for that
+ *   letter, return `null` (the key signature already "covers" this note).
+ * - When the note's accidental differs from what the key signature implies,
+ *   return the display value for the note's actual accidental.
+ * - A natural note in a key that sharpens (or flattens) that letter requires
+ *   an explicit `'natural'` sign.
+ *
+ * @param note         - Any note-like value accepted by {@link Note.create}.
+ * @param keySignature - The active key signature context.
+ * @returns The accidental to display, or `null` if none is needed.
+ */
+export function accidentalForDisplay(
+  note: NoteLike,
+  keySignature: KeySignatureInformation,
+): AccidentalDisplay | null {
+  const resolved = Note.create(note);
+  const letter = naturalFromNoteName(resolved.note);
+  const noteAccidental = accidentalFromNoteName(resolved.note);
+  const keyAccidental = keySignatureAccidentalFor(letter, keySignature);
+
+  // If the note's actual accidental matches what the key signature implies,
+  // no symbol is needed.
+  if (noteAccidental === keyAccidental) {
+    return null;
+  }
+
+  // The note deviates from the key signature — show the note's own accidental.
+  return accidentalSuffixToDisplay(noteAccidental);
+}

--- a/src/notation/index.ts
+++ b/src/notation/index.ts
@@ -9,7 +9,6 @@
  * - {@link staffPositionFor} — diatonic staff position for a note in a clef.
  * - {@link accidentalForDisplay} — accidental glyph decision given a key signature.
  * - {@link toNotationEvent} — build a notation event from a Note, Chord, or rest.
- * - {@link serializeNotationEvent} — render-neutral JSON serialization.
  *
  * Import path: `octavian/notation`
  */
@@ -17,7 +16,7 @@
 // Values
 export { staffPositionFor } from './staff-position.js';
 export { accidentalForDisplay } from './accidental-display.js';
-export { toNotationEvent, serializeNotationEvent } from './notation-event.js';
+export { toNotationEvent } from './notation-event.js';
 
 // Types
 export type {
@@ -31,10 +30,4 @@ export type {
   Clef,
   KeySignatureInformation,
 } from './types.js';
-export type {
-  NotationInput,
-  SerializedNotationEvent,
-  SerializedNotationNoteEvent,
-  SerializedNotationChordEvent,
-  SerializedNotationRestEvent,
-} from './notation-event.js';
+export type { NotationInput } from './notation-event.js';

--- a/src/notation/index.ts
+++ b/src/notation/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Renderer-neutral notation primitives for octavian.
+ *
+ * Import as `octavian/notation` (this is a subpath export, not part of the
+ * root barrel at `octavian`). The root `src/index.ts` MUST NOT re-export
+ * from this module.
+ *
+ * Provides:
+ * - {@link staffPositionFor} — diatonic staff position for a note in a clef.
+ * - {@link accidentalForDisplay} — accidental glyph decision given a key signature.
+ * - {@link toNotationEvent} — build a notation event from a Note, Chord, or rest.
+ * - {@link serializeNotationEvent} — render-neutral JSON serialization.
+ *
+ * Import path: `octavian/notation`
+ */
+
+// Values
+export { staffPositionFor } from './staff-position.js';
+export { accidentalForDisplay } from './accidental-display.js';
+export { toNotationEvent, serializeNotationEvent } from './notation-event.js';
+
+// Types
+export type {
+  StaffPosition,
+  AccidentalDisplay,
+  NotationEvent,
+  NotationNoteEvent,
+  NotationChordEvent,
+  NotationRestEvent,
+  NotationEventOptions,
+  Clef,
+  KeySignatureInformation,
+} from './types.js';
+export type {
+  NotationInput,
+  SerializedNotationEvent,
+  SerializedNotationNoteEvent,
+  SerializedNotationChordEvent,
+  SerializedNotationRestEvent,
+} from './notation-event.js';

--- a/src/notation/notation-event.ts
+++ b/src/notation/notation-event.ts
@@ -1,0 +1,218 @@
+/**
+ * Notation event construction and serialization.
+ *
+ * `toNotationEvent` converts a Note, Chord, or rest descriptor into a
+ * renderer-neutral {@link NotationEvent} that carries spelled pitches, staff
+ * positions, accidental decisions, and optional duration.
+ *
+ * `serializeNotationEvent` converts a {@link NotationEvent} to a plain JSON
+ * object — safe to `JSON.stringify` and round-trip back via
+ * `deserializeNotationEvent`.
+ */
+
+import { Note, type NoteLike } from '../note.js';
+import { Chord } from '../chord.js';
+import { keySignatureFor } from '../key-signature-catalog.js';
+import { staffPositionFor } from './staff-position.js';
+import { accidentalForDisplay } from './accidental-display.js';
+import type {
+  NotationEvent,
+  NotationNoteEvent,
+  NotationEventOptions,
+  AccidentalDisplay,
+  StaffPosition,
+} from './types.js';
+import type { KeySignatureInformation } from '../key-signature-catalog.js';
+import type { Clef } from '../clef.js';
+import type { Rational } from '../rational.js';
+
+// ---------------------------------------------------------------------------
+// Default key signature (C major — no accidentals)
+// ---------------------------------------------------------------------------
+
+const C_MAJOR: KeySignatureInformation = keySignatureFor('C', 'major');
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a single {@link NotationNoteEvent} for a Note value with context.
+ */
+function buildNoteEvent(
+  note: Note,
+  clef: Clef,
+  keySignature: KeySignatureInformation,
+  duration: Rational | undefined,
+): NotationNoteEvent {
+  const staffPosition: StaffPosition = staffPositionFor(note, clef);
+  const accidentalDisplay: AccidentalDisplay | null = accidentalForDisplay(note, keySignature);
+  const base = {
+    type: 'note' as const,
+    noteName: note.note,
+    octave: Number(note.octave),
+    accidentalDisplay,
+    staffPosition,
+  };
+  if (duration !== undefined) {
+    return { ...base, duration };
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: toNotationEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * A value that can be converted to a {@link NotationEvent}.
+ *
+ * - A {@link Note} or {@link NoteLike} string/object → note event.
+ * - A {@link Chord} → chord event (each note gets its own staff position).
+ * - `'rest'` → rest event.
+ */
+export type NotationInput = NoteLike | Chord | 'rest';
+
+/**
+ * Converts a Note, Chord, or rest into a renderer-neutral {@link NotationEvent}.
+ *
+ * @param value   - A note-like value, a {@link Chord}, or the string `'rest'`.
+ * @param options - Context: clef, key signature, and optional duration.
+ * @returns The corresponding {@link NotationEvent}.
+ * @throws {TypeError} When `value` is not a recognized input type.
+ */
+export function toNotationEvent(
+  value: NotationInput,
+  options: NotationEventOptions = {},
+): NotationEvent {
+  const clef: Clef = options.clef ?? 'treble';
+  const keySignature: KeySignatureInformation = options.keySignature ?? C_MAJOR;
+  const duration: Rational | undefined = options.duration;
+
+  if (value === 'rest') {
+    if (duration !== undefined) {
+      return { type: 'rest', duration };
+    }
+    return { type: 'rest' };
+  }
+
+  if (value instanceof Chord) {
+    const noteEvents: NotationNoteEvent[] = value.notes.map((note) =>
+      buildNoteEvent(note, clef, keySignature, duration),
+    );
+    if (duration !== undefined) {
+      return { type: 'chord', notes: noteEvents, duration };
+    }
+    return { type: 'chord', notes: noteEvents };
+  }
+
+  // Treat as NoteLike
+  const note = Note.create(value);
+  return buildNoteEvent(note, clef, keySignature, duration);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: serializeNotationEvent / deserializeNotationEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * A JSON-serializable snapshot of a {@link NotationNoteEvent}.
+ */
+export type SerializedNotationNoteEvent = {
+  readonly type: 'note';
+  readonly noteName: string;
+  readonly octave: number;
+  readonly accidentalDisplay: AccidentalDisplay | null;
+  readonly staffPosition: {
+    readonly clef: Clef;
+    readonly step: string;
+    readonly octave: number;
+    readonly lineOrSpace: number;
+    readonly ledgerLines: number;
+  };
+  readonly duration?: Rational;
+};
+
+/**
+ * A JSON-serializable snapshot of a {@link NotationChordEvent}.
+ */
+export type SerializedNotationChordEvent = {
+  readonly type: 'chord';
+  readonly notes: readonly SerializedNotationNoteEvent[];
+  readonly duration?: Rational;
+};
+
+/**
+ * A JSON-serializable snapshot of a {@link NotationRestEvent}.
+ */
+export type SerializedNotationRestEvent = {
+  readonly type: 'rest';
+  readonly duration?: Rational;
+};
+
+/**
+ * A JSON-serializable snapshot of any {@link NotationEvent}.
+ */
+export type SerializedNotationEvent =
+  | SerializedNotationNoteEvent
+  | SerializedNotationChordEvent
+  | SerializedNotationRestEvent;
+
+/**
+ * Serializes a {@link NotationNoteEvent} to a plain JSON-safe object.
+ */
+function serializeNoteEvent(event: NotationNoteEvent): SerializedNotationNoteEvent {
+  const base = {
+    type: 'note' as const,
+    noteName: event.noteName,
+    octave: event.octave,
+    accidentalDisplay: event.accidentalDisplay,
+    staffPosition: {
+      clef: event.staffPosition.clef,
+      step: event.staffPosition.step,
+      octave: event.staffPosition.octave,
+      lineOrSpace: event.staffPosition.lineOrSpace,
+      ledgerLines: event.staffPosition.ledgerLines,
+    },
+  };
+  if (event.duration !== undefined) {
+    return { ...base, duration: event.duration };
+  }
+  return base;
+}
+
+/**
+ * Converts a {@link NotationEvent} to a renderer-neutral JSON object that
+ * preserves spelling, duration, clef, and key-signature accidental decisions.
+ *
+ * @param event - The notation event to serialize.
+ * @returns A plain serializable snapshot.
+ * @throws {TypeError} When the event discriminant is not recognized.
+ */
+export function serializeNotationEvent(event: NotationEvent): SerializedNotationEvent {
+  switch (event.type) {
+    case 'note':
+      return serializeNoteEvent(event);
+    case 'chord': {
+      const base = {
+        type: 'chord' as const,
+        notes: event.notes.map(serializeNoteEvent),
+      };
+      if (event.duration !== undefined) {
+        return { ...base, duration: event.duration };
+      }
+      return base;
+    }
+    case 'rest': {
+      if (event.duration !== undefined) {
+        return { type: 'rest', duration: event.duration };
+      }
+      return { type: 'rest' };
+    }
+    default:
+      throw new TypeError(
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+        `Unknown notation event type: ${String((event as { type: unknown }).type)}.`,
+      );
+  }
+}

--- a/src/notation/notation-event.ts
+++ b/src/notation/notation-event.ts
@@ -1,13 +1,11 @@
 /**
- * Notation event construction and serialization.
+ * Notation event construction.
  *
  * `toNotationEvent` converts a Note, Chord, or rest descriptor into a
  * renderer-neutral {@link NotationEvent} that carries spelled pitches, staff
- * positions, accidental decisions, and optional duration.
- *
- * `serializeNotationEvent` converts a {@link NotationEvent} to a plain JSON
- * object — safe to `JSON.stringify` and round-trip back via
- * `deserializeNotationEvent`.
+ * positions, accidental decisions, and optional duration. All fields are plain
+ * primitives or plain objects, so the result is directly JSON-serializable via
+ * `JSON.stringify`.
  */
 
 import { Note, type NoteLike } from '../note.js';
@@ -109,110 +107,4 @@ export function toNotationEvent(
   // Treat as NoteLike
   const note = Note.create(value);
   return buildNoteEvent(note, clef, keySignature, duration);
-}
-
-// ---------------------------------------------------------------------------
-// Public API: serializeNotationEvent / deserializeNotationEvent
-// ---------------------------------------------------------------------------
-
-/**
- * A JSON-serializable snapshot of a {@link NotationNoteEvent}.
- */
-export type SerializedNotationNoteEvent = {
-  readonly type: 'note';
-  readonly noteName: string;
-  readonly octave: number;
-  readonly accidentalDisplay: AccidentalDisplay | null;
-  readonly staffPosition: {
-    readonly clef: Clef;
-    readonly step: string;
-    readonly octave: number;
-    readonly lineOrSpace: number;
-    readonly ledgerLines: number;
-  };
-  readonly duration?: Rational;
-};
-
-/**
- * A JSON-serializable snapshot of a {@link NotationChordEvent}.
- */
-export type SerializedNotationChordEvent = {
-  readonly type: 'chord';
-  readonly notes: readonly SerializedNotationNoteEvent[];
-  readonly duration?: Rational;
-};
-
-/**
- * A JSON-serializable snapshot of a {@link NotationRestEvent}.
- */
-export type SerializedNotationRestEvent = {
-  readonly type: 'rest';
-  readonly duration?: Rational;
-};
-
-/**
- * A JSON-serializable snapshot of any {@link NotationEvent}.
- */
-export type SerializedNotationEvent =
-  | SerializedNotationNoteEvent
-  | SerializedNotationChordEvent
-  | SerializedNotationRestEvent;
-
-/**
- * Serializes a {@link NotationNoteEvent} to a plain JSON-safe object.
- */
-function serializeNoteEvent(event: NotationNoteEvent): SerializedNotationNoteEvent {
-  const base = {
-    type: 'note' as const,
-    noteName: event.noteName,
-    octave: event.octave,
-    accidentalDisplay: event.accidentalDisplay,
-    staffPosition: {
-      clef: event.staffPosition.clef,
-      step: event.staffPosition.step,
-      octave: event.staffPosition.octave,
-      lineOrSpace: event.staffPosition.lineOrSpace,
-      ledgerLines: event.staffPosition.ledgerLines,
-    },
-  };
-  if (event.duration !== undefined) {
-    return { ...base, duration: event.duration };
-  }
-  return base;
-}
-
-/**
- * Converts a {@link NotationEvent} to a renderer-neutral JSON object that
- * preserves spelling, duration, clef, and key-signature accidental decisions.
- *
- * @param event - The notation event to serialize.
- * @returns A plain serializable snapshot.
- * @throws {TypeError} When the event discriminant is not recognized.
- */
-export function serializeNotationEvent(event: NotationEvent): SerializedNotationEvent {
-  switch (event.type) {
-    case 'note':
-      return serializeNoteEvent(event);
-    case 'chord': {
-      const base = {
-        type: 'chord' as const,
-        notes: event.notes.map(serializeNoteEvent),
-      };
-      if (event.duration !== undefined) {
-        return { ...base, duration: event.duration };
-      }
-      return base;
-    }
-    case 'rest': {
-      if (event.duration !== undefined) {
-        return { type: 'rest', duration: event.duration };
-      }
-      return { type: 'rest' };
-    }
-    default:
-      throw new TypeError(
-        // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-        `Unknown notation event type: ${String((event as { type: unknown }).type)}.`,
-      );
-  }
 }

--- a/src/notation/notation.test.ts
+++ b/src/notation/notation.test.ts
@@ -21,7 +21,7 @@ import { keySignatureFor } from '../key-signature-catalog.js';
 import { createRational } from '../rational.js';
 import { staffPositionFor } from './staff-position.js';
 import { accidentalForDisplay } from './accidental-display.js';
-import { toNotationEvent, serializeNotationEvent } from './notation-event.js';
+import { toNotationEvent } from './notation-event.js';
 
 // ---------------------------------------------------------------------------
 // staffPositionFor — treble clef
@@ -70,10 +70,11 @@ describe('staffPositionFor — treble clef', () => {
     expect(pos.ledgerLines).toBe(1);
   });
 
-  it('places B5 at position 11 (space above 1st ledger line)', () => {
+  it('places B5 at position 11 (space above the 1st ledger line — still 1 ledger line)', () => {
     const pos = staffPositionFor(Note.create({ note: 'B', octave: 5 }), 'treble');
     expect(pos.lineOrSpace).toBe(11);
-    expect(pos.ledgerLines).toBe(2);
+    // B5 sits in the space just above the A5 ledger line; only that one ledger line is drawn.
+    expect(pos.ledgerLines).toBe(1);
   });
 
   it('places C6 at position 12 (2nd ledger line above)', () => {
@@ -82,17 +83,18 @@ describe('staffPositionFor — treble clef', () => {
     expect(pos.ledgerLines).toBe(2);
   });
 
-  it('places D4 below bottom line in the first space (position -1)', () => {
+  it('places D4 below bottom line in the first space (position -1, no ledger line)', () => {
     const pos = staffPositionFor(Note.create({ note: 'D', octave: 4 }), 'treble');
     expect(pos.lineOrSpace).toBe(-1);
-    // D4 is in the space just below the bottom line — no full ledger line yet
-    expect(pos.ledgerLines).toBe(1);
+    // D4 is in the space just below the bottom line — no ledger line is drawn yet.
+    expect(pos.ledgerLines).toBe(0);
   });
 
-  it('places B3 at position -3 (space below first ledger line)', () => {
+  it('places B3 at position -3 (space below the C4 ledger line — still 1 ledger line)', () => {
     const pos = staffPositionFor(Note.create({ note: 'B', octave: 3 }), 'treble');
     expect(pos.lineOrSpace).toBe(-3);
-    expect(pos.ledgerLines).toBe(2);
+    // B3 sits in the space just below the C4 ledger line; only that one ledger line is drawn.
+    expect(pos.ledgerLines).toBe(1);
   });
 
   it('places A3 at position -4 (second ledger line below)', () => {
@@ -333,7 +335,8 @@ describe('toNotationEvent — chord input', () => {
     const event = toNotationEvent(chord, { clef: 'treble' });
     expect(event.type).toBe('chord');
     if (event.type === 'chord') {
-      expect(event.notes.length).toBeGreaterThan(0);
+      // C major triad (C4, E4, G4) = 3 notes
+      expect(event.notes.length).toBe(3);
       for (const note of event.notes) {
         expect(note.type).toBe('note');
         expect(typeof note.noteName).toBe('string');
@@ -390,105 +393,18 @@ describe('toNotationEvent — rest input', () => {
 });
 
 // ---------------------------------------------------------------------------
-// serializeNotationEvent
+// JSON round-trip
 // ---------------------------------------------------------------------------
 
-describe('serializeNotationEvent — note event', () => {
-  it('serializes a note event to a plain object', () => {
-    const gMajor = keySignatureFor('G', 'major');
-    const event = toNotationEvent(Note.create({ note: 'F#', octave: 4 }), {
-      clef: 'treble',
-      keySignature: gMajor,
-    });
-    const serialized = serializeNotationEvent(event);
-    expect(serialized.type).toBe('note');
-    if (serialized.type === 'note') {
-      expect(serialized.noteName).toBe('F#');
-      expect(serialized.octave).toBe(4);
-      expect(serialized.accidentalDisplay).toBeNull();
-      expect(serialized.staffPosition.clef).toBe('treble');
-      expect(serialized.staffPosition.step).toBe('F');
-    }
-  });
-
-  it('round-trips through JSON.stringify', () => {
-    const event = toNotationEvent(Note.create({ note: 'C', octave: 4 }), {
-      duration: createRational(1, 4),
-    });
-    const serialized = serializeNotationEvent(event);
-    const json = JSON.stringify(serialized);
-    const parsed = JSON.parse(json);
-    expect(parsed.type).toBe('note');
-    expect(parsed.noteName).toBe('C');
-    expect(parsed.octave).toBe(4);
-    expect(parsed.duration).toEqual({ numerator: 1, denominator: 4 });
-  });
-
-  it('omits duration from serialized note when not present', () => {
-    const event = toNotationEvent(Note.create({ note: 'C', octave: 4 }));
-    const serialized = serializeNotationEvent(event);
-    expect(serialized.type).toBe('note');
-    if (serialized.type === 'note') {
-      expect(serialized.duration).toBeUndefined();
-    }
-  });
-});
-
-describe('serializeNotationEvent — chord event', () => {
-  it('serializes a chord event', () => {
-    const chord = Chord.create('C4', 'major');
-    const event = toNotationEvent(chord, { clef: 'treble' });
-    const serialized = serializeNotationEvent(event);
-    expect(serialized.type).toBe('chord');
-    if (serialized.type === 'chord') {
-      expect(Array.isArray(serialized.notes)).toBe(true);
-      expect(serialized.notes.length).toBeGreaterThan(0);
-    }
-  });
-
-  it('serializes chord with duration', () => {
-    const chord = Chord.create('C4', 'major');
-    const event = toNotationEvent(chord, { duration: createRational(1, 2) });
-    const serialized = serializeNotationEvent(event);
-    expect(serialized.type).toBe('chord');
-    if (serialized.type === 'chord') {
-      expect(serialized.duration).toEqual({ numerator: 1, denominator: 2 });
-    }
-  });
-
-  it('omits duration from serialized chord when not present', () => {
-    const chord = Chord.create('C4', 'major');
-    const event = toNotationEvent(chord);
-    const serialized = serializeNotationEvent(event);
-    expect(serialized.type).toBe('chord');
-    if (serialized.type === 'chord') {
-      expect(serialized.duration).toBeUndefined();
-    }
-  });
-});
-
-describe('serializeNotationEvent — rest event', () => {
-  it('serializes a rest event', () => {
-    const event = toNotationEvent('rest');
-    const serialized = serializeNotationEvent(event);
-    expect(serialized.type).toBe('rest');
-  });
-
-  it('serializes rest with duration', () => {
-    const event = toNotationEvent('rest', { duration: createRational(1, 4) });
-    const serialized = serializeNotationEvent(event);
-    expect(serialized.type).toBe('rest');
-    if (serialized.type === 'rest') {
-      expect(serialized.duration).toEqual({ numerator: 1, denominator: 4 });
-    }
-  });
-
-  it('omits duration from serialized rest when not present', () => {
-    const event = toNotationEvent('rest');
-    const serialized = serializeNotationEvent(event);
-    expect(serialized.type).toBe('rest');
-    if (serialized.type === 'rest') {
-      expect(serialized.duration).toBeUndefined();
+describe('toNotationEvent — JSON round-trip', () => {
+  it('note event survives JSON.stringify / JSON.parse without losing spelling', () => {
+    const event = toNotationEvent(Note.create({ note: 'F#', octave: 4 }), { clef: 'treble' });
+    expect(JSON.parse(JSON.stringify(event))).toEqual(event);
+    // Verify spelling fields survive the round-trip
+    if (event.type === 'note') {
+      const parsed = JSON.parse(JSON.stringify(event));
+      expect(parsed.noteName).toBe('F#');
+      expect(parsed.octave).toBe(4);
     }
   });
 });
@@ -498,18 +414,20 @@ describe('serializeNotationEvent — rest event', () => {
 // ---------------------------------------------------------------------------
 
 describe('ledger line computation', () => {
-  it('space just below staff (D4 in treble) uses 1 ledger line (drawn at C4)', () => {
-    // D4 is at position -1; to reach the note the reader needs C4 ledger line
+  it('space just below staff (D4 in treble) uses 0 ledger lines (first ledger line is C4)', () => {
+    // D4 is at position -1; it sits in the space below the bottom line.
+    // The C4 ledger line (position -2) is only drawn when needed for C4 itself.
     const pos = staffPositionFor(Note.create({ note: 'D', octave: 4 }), 'treble');
     expect(pos.lineOrSpace).toBe(-1);
-    expect(pos.ledgerLines).toBe(1);
+    expect(pos.ledgerLines).toBe(0);
   });
 
-  it('space just above staff (G5 in treble) uses 1 ledger line', () => {
-    // F5 is position 8 (top line), G5 is position 9
+  it('space just above staff (G5 in treble) uses 0 ledger lines (first ledger line is A5)', () => {
+    // F5 is position 8 (top line), G5 is position 9 — the space above the top line.
+    // The A5 ledger line (position 10) is only drawn when needed for A5 itself.
     const pos = staffPositionFor(Note.create({ note: 'G', octave: 5 }), 'treble');
     expect(pos.lineOrSpace).toBe(9);
-    expect(pos.ledgerLines).toBe(1);
+    expect(pos.ledgerLines).toBe(0);
   });
 
   it('notes on the staff have 0 ledger lines', () => {
@@ -529,14 +447,6 @@ describe('ledger line computation', () => {
 // ---------------------------------------------------------------------------
 // Error arms
 // ---------------------------------------------------------------------------
-
-describe('serializeNotationEvent — unknown discriminant throws', () => {
-  it('throws TypeError for an unknown event type', () => {
-    const bogus = { type: 'unknown' } as any;
-    expect(() => serializeNotationEvent(bogus)).toThrow(TypeError);
-    expect(() => serializeNotationEvent(bogus)).toThrow('Unknown notation event type: unknown.');
-  });
-});
 
 describe('staffPositionFor — invalid clef throws', () => {
   it('throws TypeError for an unrecognized clef', () => {

--- a/src/notation/notation.test.ts
+++ b/src/notation/notation.test.ts
@@ -1,0 +1,573 @@
+/**
+ * Tests for the notation subpath module.
+ *
+ * Ground truth for staff positions:
+ * - Treble clef:
+ *   - Bottom line: E4 (position 0)
+ *   - G4: 2nd line from bottom (position 2) — the G clef reference
+ *   - Middle C (C4): 1st ledger line below (position -2, 1 ledger line)
+ *   - Top line: F5 (position 8)
+ *   - A5: 1st ledger line above (position 10, 1 ledger line)
+ * - Bass clef:
+ *   - Bottom line: G2 (position 0)
+ *   - Top line: A3 (position 8)
+ *   - Middle C (C4): 1st ledger line above (position 10, 1 ledger line)
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { Note } from '../note.js';
+import { Chord } from '../chord.js';
+import { keySignatureFor } from '../key-signature-catalog.js';
+import { createRational } from '../rational.js';
+import { staffPositionFor } from './staff-position.js';
+import { accidentalForDisplay } from './accidental-display.js';
+import { toNotationEvent, serializeNotationEvent } from './notation-event.js';
+
+// ---------------------------------------------------------------------------
+// staffPositionFor — treble clef
+// ---------------------------------------------------------------------------
+
+describe('staffPositionFor — treble clef', () => {
+  it('places E4 at position 0 (bottom line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'E', octave: 4 }), 'treble');
+    expect(pos.lineOrSpace).toBe(0);
+    expect(pos.ledgerLines).toBe(0);
+    expect(pos.step).toBe('E');
+    expect(pos.octave).toBe(4);
+    expect(pos.clef).toBe('treble');
+  });
+
+  it('places G4 at position 2 (2nd line, the G-clef reference)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'G', octave: 4 }), 'treble');
+    expect(pos.lineOrSpace).toBe(2);
+    expect(pos.ledgerLines).toBe(0);
+  });
+
+  it('places middle C (C4) at position -2 (1st ledger line below)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'C', octave: 4 }), 'treble');
+    expect(pos.lineOrSpace).toBe(-2);
+    expect(pos.ledgerLines).toBe(1);
+  });
+
+  it('C# and Cb share the same position as C4', () => {
+    const posSharp = staffPositionFor(Note.create({ note: 'C#', octave: 4 }), 'treble');
+    const posFlat = staffPositionFor(Note.create({ note: 'Cb', octave: 4 }), 'treble');
+    expect(posSharp.lineOrSpace).toBe(-2);
+    expect(posFlat.lineOrSpace).toBe(-2);
+    expect(posSharp.ledgerLines).toBe(1);
+    expect(posFlat.ledgerLines).toBe(1);
+  });
+
+  it('places F5 at position 8 (top line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'F', octave: 5 }), 'treble');
+    expect(pos.lineOrSpace).toBe(8);
+    expect(pos.ledgerLines).toBe(0);
+  });
+
+  it('places A5 at position 10 (1st ledger line above)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'A', octave: 5 }), 'treble');
+    expect(pos.lineOrSpace).toBe(10);
+    expect(pos.ledgerLines).toBe(1);
+  });
+
+  it('places B5 at position 11 (space above 1st ledger line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'B', octave: 5 }), 'treble');
+    expect(pos.lineOrSpace).toBe(11);
+    expect(pos.ledgerLines).toBe(2);
+  });
+
+  it('places C6 at position 12 (2nd ledger line above)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'C', octave: 6 }), 'treble');
+    expect(pos.lineOrSpace).toBe(12);
+    expect(pos.ledgerLines).toBe(2);
+  });
+
+  it('places D4 below bottom line in the first space (position -1)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'D', octave: 4 }), 'treble');
+    expect(pos.lineOrSpace).toBe(-1);
+    // D4 is in the space just below the bottom line — no full ledger line yet
+    expect(pos.ledgerLines).toBe(1);
+  });
+
+  it('places B3 at position -3 (space below first ledger line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'B', octave: 3 }), 'treble');
+    expect(pos.lineOrSpace).toBe(-3);
+    expect(pos.ledgerLines).toBe(2);
+  });
+
+  it('places A3 at position -4 (second ledger line below)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'A', octave: 3 }), 'treble');
+    expect(pos.lineOrSpace).toBe(-4);
+    expect(pos.ledgerLines).toBe(2);
+  });
+
+  it('accepts a note-name string with octave', () => {
+    // Use { note, octave } object form to avoid branded type issues
+    const pos = staffPositionFor({ note: 'E', octave: 4 }, 'treble');
+    expect(pos.lineOrSpace).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// staffPositionFor — bass clef
+// ---------------------------------------------------------------------------
+
+describe('staffPositionFor — bass clef', () => {
+  it('places G2 at position 0 (bottom line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'G', octave: 2 }), 'bass');
+    expect(pos.lineOrSpace).toBe(0);
+    expect(pos.ledgerLines).toBe(0);
+  });
+
+  it('places A3 at position 8 (top line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'A', octave: 3 }), 'bass');
+    expect(pos.lineOrSpace).toBe(8);
+    expect(pos.ledgerLines).toBe(0);
+  });
+
+  it('places middle C (C4) at position 10 (1st ledger line above)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'C', octave: 4 }), 'bass');
+    expect(pos.lineOrSpace).toBe(10);
+    expect(pos.ledgerLines).toBe(1);
+  });
+
+  it('places B1 below the bass staff', () => {
+    const pos = staffPositionFor(Note.create({ note: 'B', octave: 1 }), 'bass');
+    expect(pos.lineOrSpace).toBeLessThan(0);
+    expect(pos.ledgerLines).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// staffPositionFor — other clefs
+// ---------------------------------------------------------------------------
+
+describe('staffPositionFor — alto clef', () => {
+  it('places F3 at position 0 (bottom line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'F', octave: 3 }), 'alto');
+    expect(pos.lineOrSpace).toBe(0);
+    expect(pos.ledgerLines).toBe(0);
+  });
+
+  it('places middle C (C4) on the middle line of the alto staff (position 4)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'C', octave: 4 }), 'alto');
+    // C4 in alto clef sits on the middle line (position 4)
+    expect(pos.lineOrSpace).toBe(4);
+    expect(pos.ledgerLines).toBe(0);
+  });
+});
+
+describe('staffPositionFor — tenor clef', () => {
+  it('places D3 at position 0 (bottom line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'D', octave: 3 }), 'tenor');
+    expect(pos.lineOrSpace).toBe(0);
+    expect(pos.ledgerLines).toBe(0);
+  });
+});
+
+describe('staffPositionFor — soprano clef', () => {
+  it('places C4 at position 0 (bottom line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'C', octave: 4 }), 'soprano');
+    expect(pos.lineOrSpace).toBe(0);
+    expect(pos.ledgerLines).toBe(0);
+  });
+});
+
+describe('staffPositionFor — mezzo-soprano clef', () => {
+  it('places A3 at position 0 (bottom line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'A', octave: 3 }), 'mezzo-soprano');
+    expect(pos.lineOrSpace).toBe(0);
+    expect(pos.ledgerLines).toBe(0);
+  });
+});
+
+describe('staffPositionFor — baritone clef', () => {
+  it('places E2 at position 0 (bottom line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'E', octave: 2 }), 'baritone');
+    expect(pos.lineOrSpace).toBe(0);
+    expect(pos.ledgerLines).toBe(0);
+  });
+});
+
+describe('staffPositionFor — percussion clef', () => {
+  it('uses treble reference (E4 = bottom line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'E', octave: 4 }), 'percussion');
+    expect(pos.lineOrSpace).toBe(0);
+    expect(pos.ledgerLines).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// accidentalForDisplay
+// ---------------------------------------------------------------------------
+
+describe('accidentalForDisplay', () => {
+  it('returns null for F# in G major (key already sharpens F)', () => {
+    const gMajor = keySignatureFor('G', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'F#', octave: 4 }), gMajor);
+    expect(result).toBeNull();
+  });
+
+  it('returns natural for F-natural in G major', () => {
+    const gMajor = keySignatureFor('G', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'F', octave: 4 }), gMajor);
+    expect(result).toBe('natural');
+  });
+
+  it('returns sharp for G# in G major', () => {
+    const gMajor = keySignatureFor('G', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'G#', octave: 4 }), gMajor);
+    expect(result).toBe('sharp');
+  });
+
+  it('returns null for C-natural in C major', () => {
+    const cMajor = keySignatureFor('C', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'C', octave: 4 }), cMajor);
+    expect(result).toBeNull();
+  });
+
+  it('returns sharp for C# in C major', () => {
+    const cMajor = keySignatureFor('C', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'C#', octave: 4 }), cMajor);
+    expect(result).toBe('sharp');
+  });
+
+  it('returns flat for C-flat in C major', () => {
+    const cMajor = keySignatureFor('C', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'Cb', octave: 4 }), cMajor);
+    expect(result).toBe('flat');
+  });
+
+  it('returns null for Bb in Bb major', () => {
+    const bbMajor = keySignatureFor('Bb', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'Bb', octave: 4 }), bbMajor);
+    expect(result).toBeNull();
+  });
+
+  it('returns natural for B-natural in Bb major', () => {
+    const bbMajor = keySignatureFor('Bb', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'B', octave: 4 }), bbMajor);
+    expect(result).toBe('natural');
+  });
+
+  it('returns double-sharp for F## in G major', () => {
+    const gMajor = keySignatureFor('G', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'F##', octave: 4 }), gMajor);
+    expect(result).toBe('double-sharp');
+  });
+
+  it('returns double-flat for Ebb in Eb major', () => {
+    const ebMajor = keySignatureFor('Eb', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'Ebb', octave: 4 }), ebMajor);
+    expect(result).toBe('double-flat');
+  });
+
+  it('returns triple-sharp for C### in C major', () => {
+    const cMajor = keySignatureFor('C', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'C###', octave: 4 }), cMajor);
+    expect(result).toBe('triple-sharp');
+  });
+
+  it('returns triple-flat for Cbbb in C major', () => {
+    const cMajor = keySignatureFor('C', 'major');
+    const result = accidentalForDisplay(Note.create({ note: 'Cbbb', octave: 4 }), cMajor);
+    expect(result).toBe('triple-flat');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toNotationEvent — note
+// ---------------------------------------------------------------------------
+
+describe('toNotationEvent — note input', () => {
+  it('creates a note event with staff position and accidental', () => {
+    const gMajor = keySignatureFor('G', 'major');
+    const event = toNotationEvent(Note.create({ note: 'F#', octave: 4 }), {
+      clef: 'treble',
+      keySignature: gMajor,
+    });
+    expect(event.type).toBe('note');
+    if (event.type === 'note') {
+      expect(event.noteName).toBe('F#');
+      expect(event.octave).toBe(4);
+      expect(event.accidentalDisplay).toBeNull();
+      expect(event.staffPosition.clef).toBe('treble');
+      expect(event.staffPosition.step).toBe('F');
+    }
+  });
+
+  it('defaults to treble clef and C major when no options given', () => {
+    const event = toNotationEvent(Note.create({ note: 'E', octave: 4 }));
+    expect(event.type).toBe('note');
+    if (event.type === 'note') {
+      expect(event.staffPosition.lineOrSpace).toBe(0);
+      expect(event.accidentalDisplay).toBeNull();
+    }
+  });
+
+  it('attaches duration when provided', () => {
+    const quarter = createRational(1, 4);
+    const event = toNotationEvent(Note.create({ note: 'C', octave: 4 }), { duration: quarter });
+    expect(event.type).toBe('note');
+    if (event.type === 'note') {
+      expect(event.duration).toEqual(quarter);
+    }
+  });
+
+  it('omits duration when not provided', () => {
+    const event = toNotationEvent(Note.create({ note: 'C', octave: 4 }));
+    expect(event.type).toBe('note');
+    if (event.type === 'note') {
+      expect(event.duration).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toNotationEvent — chord input
+// ---------------------------------------------------------------------------
+
+describe('toNotationEvent — chord input', () => {
+  it('creates a chord event with one NotationNoteEvent per chord note', () => {
+    const chord = Chord.create('C4', 'major');
+    const event = toNotationEvent(chord, { clef: 'treble' });
+    expect(event.type).toBe('chord');
+    if (event.type === 'chord') {
+      expect(event.notes.length).toBeGreaterThan(0);
+      for (const note of event.notes) {
+        expect(note.type).toBe('note');
+        expect(typeof note.noteName).toBe('string');
+      }
+    }
+  });
+
+  it('attaches duration to a chord event', () => {
+    const chord = Chord.create('C4', 'major');
+    const half = createRational(1, 2);
+    const event = toNotationEvent(chord, { duration: half });
+    expect(event.type).toBe('chord');
+    if (event.type === 'chord') {
+      expect(event.duration).toEqual(half);
+    }
+  });
+
+  it('omits duration from chord event when not provided', () => {
+    const chord = Chord.create('C4', 'major');
+    const event = toNotationEvent(chord);
+    expect(event.type).toBe('chord');
+    if (event.type === 'chord') {
+      expect(event.duration).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toNotationEvent — rest input
+// ---------------------------------------------------------------------------
+
+describe('toNotationEvent — rest input', () => {
+  it('creates a rest event', () => {
+    const event = toNotationEvent('rest');
+    expect(event.type).toBe('rest');
+  });
+
+  it('attaches duration to a rest event', () => {
+    const whole = createRational(1, 1);
+    const event = toNotationEvent('rest', { duration: whole });
+    expect(event.type).toBe('rest');
+    if (event.type === 'rest') {
+      expect(event.duration).toEqual(whole);
+    }
+  });
+
+  it('omits duration from rest when not provided', () => {
+    const event = toNotationEvent('rest');
+    expect(event.type).toBe('rest');
+    if (event.type === 'rest') {
+      expect(event.duration).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeNotationEvent
+// ---------------------------------------------------------------------------
+
+describe('serializeNotationEvent — note event', () => {
+  it('serializes a note event to a plain object', () => {
+    const gMajor = keySignatureFor('G', 'major');
+    const event = toNotationEvent(Note.create({ note: 'F#', octave: 4 }), {
+      clef: 'treble',
+      keySignature: gMajor,
+    });
+    const serialized = serializeNotationEvent(event);
+    expect(serialized.type).toBe('note');
+    if (serialized.type === 'note') {
+      expect(serialized.noteName).toBe('F#');
+      expect(serialized.octave).toBe(4);
+      expect(serialized.accidentalDisplay).toBeNull();
+      expect(serialized.staffPosition.clef).toBe('treble');
+      expect(serialized.staffPosition.step).toBe('F');
+    }
+  });
+
+  it('round-trips through JSON.stringify', () => {
+    const event = toNotationEvent(Note.create({ note: 'C', octave: 4 }), {
+      duration: createRational(1, 4),
+    });
+    const serialized = serializeNotationEvent(event);
+    const json = JSON.stringify(serialized);
+    const parsed = JSON.parse(json);
+    expect(parsed.type).toBe('note');
+    expect(parsed.noteName).toBe('C');
+    expect(parsed.octave).toBe(4);
+    expect(parsed.duration).toEqual({ numerator: 1, denominator: 4 });
+  });
+
+  it('omits duration from serialized note when not present', () => {
+    const event = toNotationEvent(Note.create({ note: 'C', octave: 4 }));
+    const serialized = serializeNotationEvent(event);
+    expect(serialized.type).toBe('note');
+    if (serialized.type === 'note') {
+      expect(serialized.duration).toBeUndefined();
+    }
+  });
+});
+
+describe('serializeNotationEvent — chord event', () => {
+  it('serializes a chord event', () => {
+    const chord = Chord.create('C4', 'major');
+    const event = toNotationEvent(chord, { clef: 'treble' });
+    const serialized = serializeNotationEvent(event);
+    expect(serialized.type).toBe('chord');
+    if (serialized.type === 'chord') {
+      expect(Array.isArray(serialized.notes)).toBe(true);
+      expect(serialized.notes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('serializes chord with duration', () => {
+    const chord = Chord.create('C4', 'major');
+    const event = toNotationEvent(chord, { duration: createRational(1, 2) });
+    const serialized = serializeNotationEvent(event);
+    expect(serialized.type).toBe('chord');
+    if (serialized.type === 'chord') {
+      expect(serialized.duration).toEqual({ numerator: 1, denominator: 2 });
+    }
+  });
+
+  it('omits duration from serialized chord when not present', () => {
+    const chord = Chord.create('C4', 'major');
+    const event = toNotationEvent(chord);
+    const serialized = serializeNotationEvent(event);
+    expect(serialized.type).toBe('chord');
+    if (serialized.type === 'chord') {
+      expect(serialized.duration).toBeUndefined();
+    }
+  });
+});
+
+describe('serializeNotationEvent — rest event', () => {
+  it('serializes a rest event', () => {
+    const event = toNotationEvent('rest');
+    const serialized = serializeNotationEvent(event);
+    expect(serialized.type).toBe('rest');
+  });
+
+  it('serializes rest with duration', () => {
+    const event = toNotationEvent('rest', { duration: createRational(1, 4) });
+    const serialized = serializeNotationEvent(event);
+    expect(serialized.type).toBe('rest');
+    if (serialized.type === 'rest') {
+      expect(serialized.duration).toEqual({ numerator: 1, denominator: 4 });
+    }
+  });
+
+  it('omits duration from serialized rest when not present', () => {
+    const event = toNotationEvent('rest');
+    const serialized = serializeNotationEvent(event);
+    expect(serialized.type).toBe('rest');
+    if (serialized.type === 'rest') {
+      expect(serialized.duration).toBeUndefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ledger line edge cases
+// ---------------------------------------------------------------------------
+
+describe('ledger line computation', () => {
+  it('space just below staff (D4 in treble) uses 1 ledger line (drawn at C4)', () => {
+    // D4 is at position -1; to reach the note the reader needs C4 ledger line
+    const pos = staffPositionFor(Note.create({ note: 'D', octave: 4 }), 'treble');
+    expect(pos.lineOrSpace).toBe(-1);
+    expect(pos.ledgerLines).toBe(1);
+  });
+
+  it('space just above staff (G5 in treble) uses 1 ledger line', () => {
+    // F5 is position 8 (top line), G5 is position 9
+    const pos = staffPositionFor(Note.create({ note: 'G', octave: 5 }), 'treble');
+    expect(pos.lineOrSpace).toBe(9);
+    expect(pos.ledgerLines).toBe(1);
+  });
+
+  it('notes on the staff have 0 ledger lines', () => {
+    // F4 is first space in treble (position 1)
+    const pos = staffPositionFor(Note.create({ note: 'F', octave: 4 }), 'treble');
+    expect(pos.lineOrSpace).toBe(1);
+    expect(pos.ledgerLines).toBe(0);
+  });
+
+  it('notes on the top staff line have 0 ledger lines', () => {
+    const pos = staffPositionFor(Note.create({ note: 'F', octave: 5 }), 'treble');
+    expect(pos.lineOrSpace).toBe(8);
+    expect(pos.ledgerLines).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error arms
+// ---------------------------------------------------------------------------
+
+describe('serializeNotationEvent — unknown discriminant throws', () => {
+  it('throws TypeError for an unknown event type', () => {
+    const bogus = { type: 'unknown' } as any;
+    expect(() => serializeNotationEvent(bogus)).toThrow(TypeError);
+    expect(() => serializeNotationEvent(bogus)).toThrow('Unknown notation event type: unknown.');
+  });
+});
+
+describe('staffPositionFor — invalid clef throws', () => {
+  it('throws TypeError for an unrecognized clef', () => {
+    const note = Note.create({ note: 'C', octave: 4 });
+    expect(() => staffPositionFor(note, 'invalid-clef' as any)).toThrow(TypeError);
+    expect(() => staffPositionFor(note, 'invalid-clef' as any)).toThrow(
+      'Unsupported clef: invalid-clef.',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bass clef — additional ground truth
+// ---------------------------------------------------------------------------
+
+describe('bass clef additional positions', () => {
+  it('places B2 at position 2 (second line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'B', octave: 2 }), 'bass');
+    expect(pos.lineOrSpace).toBe(2);
+    expect(pos.ledgerLines).toBe(0);
+  });
+
+  it('places D3 at position 4 (middle line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'D', octave: 3 }), 'bass');
+    expect(pos.lineOrSpace).toBe(4);
+    expect(pos.ledgerLines).toBe(0);
+  });
+
+  it('places F3 at position 6 (4th line)', () => {
+    const pos = staffPositionFor(Note.create({ note: 'F', octave: 3 }), 'bass');
+    expect(pos.lineOrSpace).toBe(6);
+    expect(pos.ledgerLines).toBe(0);
+  });
+});

--- a/src/notation/staff-position.ts
+++ b/src/notation/staff-position.ts
@@ -84,18 +84,25 @@ const STAFF_TOP = 8;
 /**
  * Computes how many ledger lines are needed for a given `lineOrSpace` value.
  *
+ * Ledger lines are only drawn at the line positions themselves (even offsets
+ * from the staff edge), not the spaces between them. A note in the space just
+ * beyond the staff (an odd offset) needs zero ledger lines; the first ledger
+ * line appears at the next line position.
+ *
  * - 0 when the note is on the staff (0 ≤ pos ≤ 8).
- * - Below: ledger lines are drawn at even positions -2, -4, -6, …
- * - Above: ledger lines are drawn at even positions 10, 12, 14, …
+ * - Below: ledger lines are at even positions -2 (C4), -4 (A3), -6, …
+ *   so D4 (-1) → 0, C4 (-2) → 1, B3 (-3) → 1, A3 (-4) → 2.
+ * - Above: ledger lines are at even positions 10 (A5), 12 (C6), 14, …
+ *   so G5 (9) → 0, A5 (10) → 1, B5 (11) → 1, C6 (12) → 2.
  */
 function ledgerLinesForPosition(lineOrSpace: number): number {
   if (lineOrSpace >= STAFF_BOTTOM && lineOrSpace <= STAFF_TOP) {
     return 0;
   }
   if (lineOrSpace < STAFF_BOTTOM) {
-    return Math.ceil(-lineOrSpace / 2);
+    return Math.floor(-lineOrSpace / 2);
   }
-  return Math.ceil((lineOrSpace - STAFF_TOP) / 2);
+  return Math.floor((lineOrSpace - STAFF_TOP) / 2);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/notation/staff-position.ts
+++ b/src/notation/staff-position.ts
@@ -1,0 +1,130 @@
+/**
+ * Staff position calculation for notation rendering.
+ *
+ * Computes where a note sits on the staff given its natural letter and octave.
+ * Accidentals (sharps/flats) do NOT affect staff position — C, C#, and Cb
+ * all occupy the same line or space.
+ */
+
+import type { Clef } from '../clef.js';
+import type { Natural } from '../note-spellings.js';
+import { NATURALS, naturalFromNoteName } from '../note-spellings.js';
+import { Note, type NoteLike } from '../note.js';
+import type { StaffPosition } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Clef reference points
+// ---------------------------------------------------------------------------
+
+/**
+ * The reference point for a clef: the note on the bottom line of the staff
+ * (position 0 in diatonic space). Used to compute `lineOrSpace` for any note.
+ */
+type ClefReference = {
+  readonly natural: Natural;
+  readonly octave: number;
+};
+
+const CLEF_REFERENCES: Record<Clef, ClefReference> = {
+  treble: { natural: 'E', octave: 4 },
+  bass: { natural: 'G', octave: 2 },
+  alto: { natural: 'F', octave: 3 },
+  tenor: { natural: 'D', octave: 3 },
+  soprano: { natural: 'C', octave: 4 },
+  'mezzo-soprano': { natural: 'A', octave: 3 },
+  baritone: { natural: 'E', octave: 2 },
+  percussion: { natural: 'E', octave: 4 },
+};
+
+// ---------------------------------------------------------------------------
+// Diatonic helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the index of a natural letter in NATURALS (0 = C, …, 6 = B).
+ *
+ * `Natural` is the exact union of letters in `NATURALS`, so indexOf always
+ * returns a valid 0..6 index.
+ */
+function naturalIndex(natural: Natural): number {
+  return NATURALS.indexOf(natural);
+}
+
+/**
+ * Computes the diatonic steps between two notes (note B relative to note A).
+ *
+ * Result is positive when B is above A, negative when below.
+ *
+ * @param aNatural - Natural letter of reference note A.
+ * @param aOctave  - Octave of reference note A.
+ * @param bNatural - Natural letter of note B.
+ * @param bOctave  - Octave of note B.
+ */
+function diatonicSteps(
+  aNatural: Natural,
+  aOctave: number,
+  bNatural: Natural,
+  bOctave: number,
+): number {
+  return naturalIndex(bNatural) - naturalIndex(aNatural) + (bOctave - aOctave) * NATURALS.length;
+}
+
+// ---------------------------------------------------------------------------
+// Ledger line count
+// ---------------------------------------------------------------------------
+
+/**
+ * The staff spans positions 0 (bottom line) through 8 (top line).
+ */
+const STAFF_BOTTOM = 0;
+
+/** Top staff line position. */
+const STAFF_TOP = 8;
+
+/**
+ * Computes how many ledger lines are needed for a given `lineOrSpace` value.
+ *
+ * - 0 when the note is on the staff (0 ≤ pos ≤ 8).
+ * - Below: ledger lines are drawn at even positions -2, -4, -6, …
+ * - Above: ledger lines are drawn at even positions 10, 12, 14, …
+ */
+function ledgerLinesForPosition(lineOrSpace: number): number {
+  if (lineOrSpace >= STAFF_BOTTOM && lineOrSpace <= STAFF_TOP) {
+    return 0;
+  }
+  if (lineOrSpace < STAFF_BOTTOM) {
+    return Math.ceil(-lineOrSpace / 2);
+  }
+  return Math.ceil((lineOrSpace - STAFF_TOP) / 2);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the diatonic staff position of a note for the given clef.
+ *
+ * Staff position depends on the note letter (step) and octave only — the
+ * accidental (C, C#, Cb) does NOT affect position.
+ *
+ * @param note - Any note-like value accepted by {@link Note.create}.
+ * @param clef - The clef context.
+ * @returns The {@link StaffPosition} for the note.
+ * @throws {TypeError} When `clef` is not a supported value.
+ */
+export function staffPositionFor(note: NoteLike, clef: Clef): StaffPosition {
+  const resolved = Note.create(note);
+  const step = naturalFromNoteName(resolved.note);
+  const octave = Number(resolved.octave);
+
+  const reference = CLEF_REFERENCES[clef];
+  if (!reference) {
+    throw new TypeError(`Unsupported clef: ${clef}.`);
+  }
+
+  const lineOrSpace = diatonicSteps(reference.natural, reference.octave, step, octave);
+  const ledgerLines = ledgerLinesForPosition(lineOrSpace);
+
+  return { clef, step, octave, lineOrSpace, ledgerLines };
+}

--- a/src/notation/types.ts
+++ b/src/notation/types.ts
@@ -1,0 +1,127 @@
+/**
+ * Domain types for the notation subpath module.
+ *
+ * These types are renderer-neutral: they describe the musical and visual
+ * properties of a notation event without specifying how it is drawn.
+ */
+
+import type { Clef } from '../clef.js';
+import type { Natural, NoteName } from '../note-spellings.js';
+import type { KeySignatureInformation } from '../key-signature-catalog.js';
+import type { Rational } from '../rational.js';
+
+// ---------------------------------------------------------------------------
+// Re-export upstream types needed by consumers of this module
+// ---------------------------------------------------------------------------
+
+export type { Clef, KeySignatureInformation };
+
+// ---------------------------------------------------------------------------
+// StaffPosition
+// ---------------------------------------------------------------------------
+
+/**
+ * A diatonic staff position for a note relative to a given clef.
+ *
+ * - `clef`: the clef context for this position.
+ * - `step`: the note's natural letter (the "step" in diatonic space).
+ * - `octave`: the octave of the note.
+ * - `lineOrSpace`: integer diatonic distance from the bottom line of the
+ *   staff (0 = bottom line, 1 = first space, 2 = second line, …, 8 = top
+ *   line). Negative values are below the staff; values > 8 are above.
+ * - `ledgerLines`: the number of ledger lines needed (0 when on-staff).
+ *   Positive values are valid for both above and below (direction is
+ *   determined by the sign of `lineOrSpace`).
+ */
+export type StaffPosition = {
+  readonly clef: Clef;
+  readonly step: Natural;
+  readonly octave: number;
+  readonly lineOrSpace: number;
+  readonly ledgerLines: number;
+};
+
+// ---------------------------------------------------------------------------
+// AccidentalDisplay
+// ---------------------------------------------------------------------------
+
+/**
+ * The accidental glyph a renderer must draw for a note in context.
+ *
+ * `null` means no accidental is drawn (the key signature already implies the
+ * correct spelling for this note).
+ */
+export type AccidentalDisplay =
+  | 'sharp'
+  | 'flat'
+  | 'natural'
+  | 'double-sharp'
+  | 'double-flat'
+  | 'triple-sharp'
+  | 'triple-flat';
+
+// ---------------------------------------------------------------------------
+// NotationEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * A notation note event — a single sounding pitch with staff context.
+ */
+export type NotationNoteEvent = {
+  /** Discriminant. */
+  readonly type: 'note';
+  /** The note name (letter + accidental). */
+  readonly noteName: NoteName;
+  /** The octave. */
+  readonly octave: number;
+  /** The accidental glyph to draw, or `null` if the key signature implies the correct spelling. */
+  readonly accidentalDisplay: AccidentalDisplay | null;
+  /** The note's position on the staff. */
+  readonly staffPosition: StaffPosition;
+  /** Optional duration as a whole-note fraction. */
+  readonly duration?: Rational;
+};
+
+/**
+ * A notation chord event — multiple simultaneous pitches with staff context.
+ */
+export type NotationChordEvent = {
+  /** Discriminant. */
+  readonly type: 'chord';
+  /** The notes in the chord, each with staff context. */
+  readonly notes: readonly NotationNoteEvent[];
+  /** Optional duration as a whole-note fraction. */
+  readonly duration?: Rational;
+};
+
+/**
+ * A notation rest event.
+ */
+export type NotationRestEvent = {
+  /** Discriminant. */
+  readonly type: 'rest';
+  /** Optional duration as a whole-note fraction. */
+  readonly duration?: Rational;
+};
+
+/**
+ * A renderer-neutral notation event that carries spelled pitch(es), optional
+ * duration, and staff context.
+ */
+export type NotationEvent = NotationNoteEvent | NotationChordEvent | NotationRestEvent;
+
+// ---------------------------------------------------------------------------
+// Options for toNotationEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link toNotationEvent}.
+ */
+export type NotationEventOptions = {
+  /** The clef context. Defaults to `'treble'`. */
+  readonly clef?: Clef;
+  /** The key signature context. When absent, C major (no accidentals) is assumed. */
+  readonly keySignature?: KeySignatureInformation;
+  /** Optional duration as a whole-note fraction. */
+  readonly duration?: Rational;
+};

--- a/src/performance-timing/index.ts
+++ b/src/performance-timing/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Performance timing analysis helpers for octavian.
+ *
+ * Import as `octavian/perf-timing` (this is a subpath export, not part of
+ * the root barrel at `octavian`). The root `src/index.ts` MUST NOT re-export
+ * from this module.
+ *
+ * Provides pure math over performed events vs. an expected grid/sequence:
+ * - {@link quantizePerformance} — snap onsets to a grid, preserving humanized deviations
+ * - {@link comparePerformanceTiming} — match performed onsets to expected, classify timing
+ * - {@link classifyTimingError} — classify a single signed error as early/late/on-time
+ * - {@link estimateTempoFromOnsets} — derive BPM from median inter-onset interval
+ * - {@link measureSwingRatio} — estimate swing ratio from onset pairs
+ *
+ * Import path: `octavian/perf-timing`
+ */
+
+// Values (functions) first, then types.
+export {
+  quantizePerformance,
+  classifyTimingError,
+  comparePerformanceTiming,
+  estimateTempoFromOnsets,
+  measureSwingRatio,
+} from './performance-timing.js';
+
+export type { QuantizeOptions, ClassifyTimingOptions } from './performance-timing.js';
+
+export type {
+  PerformedEvent,
+  TimingErrorClass,
+  QuantizedEvent,
+  QuantizedPerformance,
+  MatchedTimingEvent,
+  MissedTimingEvent,
+  ExtraTimingEvent,
+  TimingEvent,
+  CompareTimingOptions,
+  TimingComparison,
+  TempoEstimate,
+  EstimateTempoOptions,
+  MeasureSwingOptions,
+} from './types.js';

--- a/src/performance-timing/performance-timing.test.ts
+++ b/src/performance-timing/performance-timing.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Tests for performance timing analysis.
+ *
+ * Ground-truth assertions use external, manually-verified values (per spec):
+ * - Onsets [0, 0.5, 1.0, 1.5] at 0.5s grid ⇒ 120 BPM
+ * - Performed 0.52 vs expected 0.5, tol 0.05 ⇒ error=+0.02 ⇒ 'on-time'
+ * - Performed 0.6 vs expected 0.5, tol 0.05 ⇒ error=+0.1 ⇒ 'late'
+ * - latencyOffset 0.1: performed 0.6 − 0.1 = 0.5 vs expected 0.5 ⇒ 'on-time'
+ * - Missing performed onset ⇒ 'missed'; extra performed onset ⇒ 'extra'
+ */
+
+import { describe, it, expect } from 'bun:test';
+
+import {
+  quantizePerformance,
+  classifyTimingError,
+  comparePerformanceTiming,
+  estimateTempoFromOnsets,
+  measureSwingRatio,
+} from './performance-timing.js';
+
+import type { PerformedEvent } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(onsetSeconds: number, extra?: Partial<PerformedEvent>): PerformedEvent {
+  return { onsetSeconds, ...extra };
+}
+
+// ---------------------------------------------------------------------------
+// quantizePerformance
+// ---------------------------------------------------------------------------
+
+describe('quantizePerformance', () => {
+  it('snaps onsets to the nearest grid multiple', () => {
+    const events = [makeEvent(0.0), makeEvent(0.52), makeEvent(1.03), makeEvent(1.48)];
+    const result = quantizePerformance(events, 0.5);
+
+    expect(result.gridSeconds).toBe(0.5);
+    expect(result.offsetSeconds).toBe(0);
+    expect(result.events).toHaveLength(4);
+
+    // 0.52 snaps to 0.5
+    expect(result.events[1]?.quantizedOnsetSeconds).toBe(0.5);
+    expect(result.events[1]?.originalOnsetSeconds).toBe(0.52);
+    // deviation = 0.52 - 0.5 = 0.02 (positive = late relative to grid)
+    expect(result.events[1]?.deviationSeconds).toBeCloseTo(0.02, 10);
+
+    // 1.03 snaps to 1.0
+    expect(result.events[2]?.quantizedOnsetSeconds).toBe(1.0);
+    expect(result.events[2]?.deviationSeconds).toBeCloseTo(0.03, 10);
+
+    // 1.48 snaps to 1.5
+    expect(result.events[3]?.quantizedOnsetSeconds).toBe(1.5);
+    expect(result.events[3]?.deviationSeconds).toBeCloseTo(-0.02, 10);
+  });
+
+  it('preserves deviation for exactly on-grid events', () => {
+    const result = quantizePerformance([makeEvent(0.5)], 0.5);
+    expect(result.events[0]?.quantizedOnsetSeconds).toBe(0.5);
+    expect(result.events[0]?.deviationSeconds).toBe(0);
+  });
+
+  it('applies a positive offsetSeconds before snapping', () => {
+    // onset 0.4, offset +0.1 ⇒ shifted 0.5, snaps to 0.5
+    // deviation = 0.4 − 0.5 = −0.1
+    const result = quantizePerformance([makeEvent(0.4)], 0.5, { offsetSeconds: 0.1 });
+    expect(result.offsetSeconds).toBe(0.1);
+    expect(result.events[0]?.quantizedOnsetSeconds).toBe(0.5);
+    expect(result.events[0]?.deviationSeconds).toBeCloseTo(-0.1, 10);
+  });
+
+  it('applies a negative offsetSeconds before snapping', () => {
+    // onset 0.6, offset -0.1 ⇒ shifted 0.5, snaps to 0.5
+    // deviation = 0.6 − 0.5 = 0.1
+    const result = quantizePerformance([makeEvent(0.6)], 0.5, { offsetSeconds: -0.1 });
+    expect(result.offsetSeconds).toBe(-0.1);
+    expect(result.events[0]?.quantizedOnsetSeconds).toBe(0.5);
+    expect(result.events[0]?.deviationSeconds).toBeCloseTo(0.1, 10);
+  });
+
+  it('passes through optional durationSeconds', () => {
+    const result = quantizePerformance([makeEvent(0.5, { durationSeconds: 0.25 })], 0.5);
+    expect(result.events[0]?.durationSeconds).toBe(0.25);
+  });
+
+  it('passes through optional note and velocity together', async () => {
+    const { Note } = await import('../note.js');
+    const note = Note.create({ note: 'C', octave: 4 as never });
+    const result = quantizePerformance([makeEvent(0.0, { note, velocity: 64 })], 0.5);
+    expect(result.events[0]?.note).toBe(note);
+    expect(result.events[0]?.velocity).toBe(64);
+  });
+
+  it('passes through optional note without velocity', async () => {
+    const { Note } = await import('../note.js');
+    const note = Note.create({ note: 'D', octave: 4 as never });
+    const result = quantizePerformance([makeEvent(0.0, { note })], 0.5);
+    expect(result.events[0]?.note).toBe(note);
+    expect(result.events[0]?.velocity).toBeUndefined();
+  });
+
+  it('passes through optional velocity without note', () => {
+    const result = quantizePerformance([makeEvent(0.0, { velocity: 80 })], 0.5);
+    expect(result.events[0]?.velocity).toBe(80);
+    expect(result.events[0]?.note).toBeUndefined();
+  });
+
+  it('preserves all optional fields together (durationSeconds + note + velocity)', async () => {
+    const { Note } = await import('../note.js');
+    const note = Note.create({ note: 'E', octave: 4 as never });
+    const event = makeEvent(0.52, { durationSeconds: 0.3, note, velocity: 100 });
+    const result = quantizePerformance([event], 0.5);
+    const qe = result.events[0];
+    expect(qe?.originalOnsetSeconds).toBe(0.52);
+    expect(qe?.quantizedOnsetSeconds).toBe(0.5);
+    expect(qe?.deviationSeconds).toBeCloseTo(0.02, 10);
+    expect(qe?.durationSeconds).toBe(0.3);
+    expect(qe?.note).toBe(note);
+    expect(qe?.velocity).toBe(100);
+  });
+
+  it('handles empty event array', () => {
+    const result = quantizePerformance([], 0.5);
+    expect(result.events).toHaveLength(0);
+  });
+
+  it('throws RangeError for non-positive gridSeconds', () => {
+    expect(() => quantizePerformance([], 0)).toThrow(RangeError);
+    expect(() => quantizePerformance([], -0.5)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite gridSeconds', () => {
+    expect(() => quantizePerformance([], Infinity)).toThrow(RangeError);
+    expect(() => quantizePerformance([], NaN)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite offsetSeconds', () => {
+    expect(() => quantizePerformance([], 0.5, { offsetSeconds: NaN })).toThrow(RangeError);
+    expect(() => quantizePerformance([], 0.5, { offsetSeconds: Infinity })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite onset in event', () => {
+    expect(() => quantizePerformance([makeEvent(NaN)], 0.5)).toThrow(RangeError);
+    expect(() => quantizePerformance([makeEvent(Infinity)], 0.5)).toThrow(RangeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyTimingError
+// ---------------------------------------------------------------------------
+
+describe('classifyTimingError', () => {
+  it('classifies 0.02 error with 0.05 tolerance as on-time (ground truth: 0.52 vs 0.5)', () => {
+    // error = 0.52 - 0.5 = 0.02; 0.02 <= 0.05 ⇒ on-time
+    expect(classifyTimingError(0.02, { toleranceSeconds: 0.05 })).toBe('on-time');
+  });
+
+  it('classifies 0.1 error with 0.05 tolerance as late (ground truth: 0.6 vs 0.5)', () => {
+    // error = 0.6 - 0.5 = 0.1; 0.1 > 0.05 ⇒ late
+    expect(classifyTimingError(0.1, { toleranceSeconds: 0.05 })).toBe('late');
+  });
+
+  it('classifies negative error within tolerance as on-time', () => {
+    // 0.45 vs 0.5: error = 0.45 - 0.5 = -0.049... <= 0.05 ⇒ on-time
+    const error = 0.45 - 0.5; // ≈ -0.04999...
+    expect(classifyTimingError(error, { toleranceSeconds: 0.05 })).toBe('on-time');
+  });
+
+  it('classifies negative error beyond tolerance as early', () => {
+    // error = -0.1; 0.1 > 0.05 and negative ⇒ early
+    expect(classifyTimingError(-0.1, { toleranceSeconds: 0.05 })).toBe('early');
+  });
+
+  it('classifies exact zero as on-time', () => {
+    expect(classifyTimingError(0)).toBe('on-time');
+  });
+
+  it('uses default tolerance of 0.05', () => {
+    expect(classifyTimingError(0.04)).toBe('on-time');
+    expect(classifyTimingError(0.06)).toBe('late');
+    expect(classifyTimingError(-0.06)).toBe('early');
+  });
+
+  it('classifies exactly at tolerance boundary as on-time (inclusive)', () => {
+    expect(classifyTimingError(0.05, { toleranceSeconds: 0.05 })).toBe('on-time');
+    expect(classifyTimingError(-0.05, { toleranceSeconds: 0.05 })).toBe('on-time');
+  });
+
+  it('classifies just beyond tolerance as late/early', () => {
+    expect(classifyTimingError(0.0501, { toleranceSeconds: 0.05 })).toBe('late');
+    expect(classifyTimingError(-0.0501, { toleranceSeconds: 0.05 })).toBe('early');
+  });
+
+  it('throws RangeError for non-finite errorSeconds', () => {
+    expect(() => classifyTimingError(NaN)).toThrow(RangeError);
+    expect(() => classifyTimingError(Infinity)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for negative toleranceSeconds', () => {
+    expect(() => classifyTimingError(0.01, { toleranceSeconds: -0.01 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite toleranceSeconds', () => {
+    expect(() => classifyTimingError(0.01, { toleranceSeconds: NaN })).toThrow(RangeError);
+    expect(() => classifyTimingError(0.01, { toleranceSeconds: Infinity })).toThrow(RangeError);
+  });
+
+  it('allows zero toleranceSeconds (only exact match is on-time)', () => {
+    expect(classifyTimingError(0, { toleranceSeconds: 0 })).toBe('on-time');
+    expect(classifyTimingError(0.001, { toleranceSeconds: 0 })).toBe('late');
+    expect(classifyTimingError(-0.001, { toleranceSeconds: 0 })).toBe('early');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// comparePerformanceTiming
+// ---------------------------------------------------------------------------
+
+describe('comparePerformanceTiming', () => {
+  it('classifies performed 0.52 vs expected 0.5 as on-time (ground truth)', () => {
+    const result = comparePerformanceTiming([0.5], [makeEvent(0.52)], { toleranceSeconds: 0.05 });
+    expect(result.onTimeCount).toBe(1);
+    expect(result.earlyCount).toBe(0);
+    expect(result.lateCount).toBe(0);
+    expect(result.missedCount).toBe(0);
+    expect(result.extraCount).toBe(0);
+
+    const event = result.events[0];
+    expect(event?.type).toBe('matched');
+    if (event?.type === 'matched') {
+      expect(event.classification).toBe('on-time');
+      expect(event.errorSeconds).toBeCloseTo(0.02, 10);
+    }
+  });
+
+  it('classifies performed 0.6 vs expected 0.5 as late (ground truth)', () => {
+    const result = comparePerformanceTiming([0.5], [makeEvent(0.6)], { toleranceSeconds: 0.05 });
+    expect(result.lateCount).toBe(1);
+    expect(result.onTimeCount).toBe(0);
+
+    const event = result.events[0];
+    if (event?.type === 'matched') {
+      expect(event.classification).toBe('late');
+      expect(event.errorSeconds).toBeCloseTo(0.1, 10);
+    }
+  });
+
+  it('applies latencyOffset: performed 0.6 - 0.1 = 0.5 vs expected 0.5 ⇒ on-time (ground truth)', () => {
+    const result = comparePerformanceTiming([0.5], [makeEvent(0.6)], {
+      toleranceSeconds: 0.05,
+      latencyOffsetSeconds: 0.1,
+    });
+    expect(result.onTimeCount).toBe(1);
+    expect(result.latencyOffsetSeconds).toBe(0.1);
+
+    const event = result.events[0];
+    if (event?.type === 'matched') {
+      expect(event.performedOnsetSeconds).toBeCloseTo(0.5, 10);
+      expect(event.classification).toBe('on-time');
+    }
+  });
+
+  it('reports missed onset when no performed match', () => {
+    const result = comparePerformanceTiming([0.5, 1.0], [makeEvent(0.5)], {
+      toleranceSeconds: 0.05,
+    });
+    expect(result.missedCount).toBe(1);
+
+    const missed = result.events.find((e) => e.type === 'missed');
+    expect(missed?.type).toBe('missed');
+    if (missed?.type === 'missed') {
+      expect(missed.expectedOnsetSeconds).toBe(1.0);
+    }
+  });
+
+  it('reports extra onset when no expected match', () => {
+    const result = comparePerformanceTiming([0.5], [makeEvent(0.5), makeEvent(0.75)], {
+      toleranceSeconds: 0.05,
+    });
+    expect(result.extraCount).toBe(1);
+
+    const extra = result.events.find((e) => e.type === 'extra');
+    expect(extra?.type).toBe('extra');
+    if (extra?.type === 'extra') {
+      expect(extra.performedOnsetSeconds).toBeCloseTo(0.75, 10);
+    }
+  });
+
+  it('matches nearest neighbor correctly (greedy assignment)', () => {
+    // expected=[0.5, 1.0], performed=[0.9]
+    // 0.9 is closer to 1.0 (dist 0.1) than to 0.5 (dist 0.4)
+    // → match 0.9↔1.0, miss 0.5
+    const result = comparePerformanceTiming([0.5, 1.0], [makeEvent(0.9)], {
+      toleranceSeconds: 0.05,
+    });
+    expect(result.missedCount).toBe(1);
+    expect(result.extraCount).toBe(0);
+
+    const matched = result.events.find((e) => e.type === 'matched');
+    if (matched?.type === 'matched') {
+      expect(matched.expectedOnsetSeconds).toBe(1.0);
+      expect(matched.performedOnsetSeconds).toBeCloseTo(0.9, 10);
+    }
+
+    const missed = result.events.find((e) => e.type === 'missed');
+    if (missed?.type === 'missed') {
+      expect(missed.expectedOnsetSeconds).toBe(0.5);
+    }
+  });
+
+  it('handles empty performed array (all expected are missed)', () => {
+    const result = comparePerformanceTiming([0.5, 1.0], []);
+    expect(result.missedCount).toBe(2);
+    expect(result.extraCount).toBe(0);
+    expect(result.onTimeCount).toBe(0);
+  });
+
+  it('handles empty expected array (all performed are extra)', () => {
+    const result = comparePerformanceTiming([], [makeEvent(0.5), makeEvent(1.0)]);
+    expect(result.extraCount).toBe(2);
+    expect(result.missedCount).toBe(0);
+  });
+
+  it('handles both empty', () => {
+    const result = comparePerformanceTiming([], []);
+    expect(result.events).toHaveLength(0);
+    expect(result.missedCount).toBe(0);
+    expect(result.extraCount).toBe(0);
+  });
+
+  it('classifies early onset correctly', () => {
+    const result = comparePerformanceTiming([0.5], [makeEvent(0.3)], { toleranceSeconds: 0.05 });
+    expect(result.earlyCount).toBe(1);
+    const event = result.events[0];
+    if (event?.type === 'matched') {
+      expect(event.classification).toBe('early');
+      expect(event.errorSeconds).toBeCloseTo(-0.2, 10);
+    }
+  });
+
+  it('accepts a Sequence as expected input (note/chord events only)', async () => {
+    const { Sequence, musicalTime } = await import('../sequences/sequence.js');
+    const { Note } = await import('../note.js');
+
+    const note = Note.create({ note: 'C', octave: 4 as never });
+    const seq = Sequence.create(
+      [
+        { type: 'note', note, start: musicalTime(0, 1), duration: musicalTime(1, 4) },
+        { type: 'rest', start: musicalTime(1, 4), duration: musicalTime(1, 4) },
+        { type: 'note', note, start: musicalTime(1, 2), duration: musicalTime(1, 4) },
+      ],
+      { tempo: 120 },
+    );
+
+    // At 120 BPM, quarter notes: start=0 ⇒ 0s, start=1/2 ⇒ 1.0s
+    // (1/4) beat at 120 bpm: 1 beat = 0.5s; so 1/4 whole note = 1 beat = 0.5s
+    // Actually: quarter note start = 0 ⇒ 0s; half-note start = 1/2 ⇒ 1.0s
+    const result = comparePerformanceTiming(seq, [makeEvent(0.0), makeEvent(1.0)], {
+      toleranceSeconds: 0.05,
+    });
+
+    // Rests don't contribute expected onsets, so 2 expected onsets.
+    expect(result.onTimeCount).toBe(2);
+    expect(result.missedCount).toBe(0);
+  });
+
+  it('uses default tolerance of 0.05 and latency of 0', () => {
+    const result = comparePerformanceTiming([0.5], [makeEvent(0.52)]);
+    expect(result.toleranceSeconds).toBe(0.05);
+    expect(result.latencyOffsetSeconds).toBe(0);
+    expect(result.onTimeCount).toBe(1);
+  });
+
+  it('throws RangeError for negative toleranceSeconds', () => {
+    expect(() =>
+      comparePerformanceTiming([0.5], [makeEvent(0.5)], { toleranceSeconds: -0.01 }),
+    ).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite latencyOffsetSeconds', () => {
+    expect(() =>
+      comparePerformanceTiming([0.5], [makeEvent(0.5)], { latencyOffsetSeconds: NaN }),
+    ).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite expected onset', () => {
+    expect(() => comparePerformanceTiming([NaN], [makeEvent(0.5)])).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite performed onset', () => {
+    expect(() => comparePerformanceTiming([0.5], [makeEvent(Infinity)])).toThrow(RangeError);
+  });
+
+  it('carries the original PerformedEvent on matched events', () => {
+    const event = makeEvent(0.5, { velocity: 64 });
+    const result = comparePerformanceTiming([0.5], [event]);
+    const matched = result.events[0];
+    if (matched?.type === 'matched') {
+      expect(matched.event).toBe(event);
+    }
+  });
+
+  it('carries the original PerformedEvent on extra events', () => {
+    const event = makeEvent(0.75);
+    const result = comparePerformanceTiming([], [event]);
+    const extra = result.events[0];
+    if (extra?.type === 'extra') {
+      expect(extra.event).toBe(event);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// estimateTempoFromOnsets
+// ---------------------------------------------------------------------------
+
+describe('estimateTempoFromOnsets', () => {
+  it('returns 120 BPM for onsets [0, 0.5, 1.0, 1.5] (ground truth)', () => {
+    const result = estimateTempoFromOnsets([0, 0.5, 1.0, 1.5]);
+    expect(result).not.toBeNull();
+    expect(result?.bpm).toBeCloseTo(120, 8);
+    expect(result?.medianInterOnsetSeconds).toBeCloseTo(0.5, 8);
+    expect(result?.intervalCount).toBe(3);
+  });
+
+  it('returns 60 BPM for onsets 1 second apart', () => {
+    const result = estimateTempoFromOnsets([0, 1, 2, 3]);
+    expect(result?.bpm).toBeCloseTo(60, 8);
+  });
+
+  it('returns null for fewer than 2 onsets', () => {
+    expect(estimateTempoFromOnsets([])).toBeNull();
+    expect(estimateTempoFromOnsets([0.5])).toBeNull();
+  });
+
+  it('works with exactly 2 onsets', () => {
+    const result = estimateTempoFromOnsets([0, 0.5]);
+    expect(result?.bpm).toBeCloseTo(120, 8);
+    expect(result?.intervalCount).toBe(1);
+  });
+
+  it('handles unsorted onsets by sorting internally', () => {
+    // [1.5, 0, 1.0, 0.5] sorted ⇒ [0, 0.5, 1.0, 1.5] ⇒ same as ground truth
+    const result = estimateTempoFromOnsets([1.5, 0, 1.0, 0.5]);
+    expect(result?.bpm).toBeCloseTo(120, 8);
+  });
+
+  it('applies beatsPerInterval: 2 onsets per measure at 60 BPM still gives 60 BPM', () => {
+    // IOI = 2.0s, beatsPerInterval=2 ⇒ secondsPerBeat = 1.0 ⇒ 60 BPM
+    const result = estimateTempoFromOnsets([0, 2, 4], { beatsPerInterval: 2 });
+    expect(result?.bpm).toBeCloseTo(60, 8);
+  });
+
+  it('throws RangeError for non-finite onset', () => {
+    expect(() => estimateTempoFromOnsets([0, NaN, 1.0])).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-positive beatsPerInterval', () => {
+    expect(() => estimateTempoFromOnsets([0, 0.5], { beatsPerInterval: 0 })).toThrow(RangeError);
+    expect(() => estimateTempoFromOnsets([0, 0.5], { beatsPerInterval: -1 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for non-finite beatsPerInterval', () => {
+    expect(() => estimateTempoFromOnsets([0, 0.5], { beatsPerInterval: NaN })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for zero/negative IOI (duplicate or unsorted timestamps)', () => {
+    expect(() => estimateTempoFromOnsets([0, 0, 1.0])).toThrow(RangeError);
+    // Reversed would be sorted internally so this is fine; test true duplicates only
+  });
+
+  it('uses median (not mean) for robustness with outliers', () => {
+    // IOIs: [0.5, 0.5, 0.5, 5.0] — outlier at end
+    // median of [0.5, 0.5, 0.5, 5.0] = (0.5+0.5)/2 = 0.5
+    // mean = (0.5+0.5+0.5+5.0)/4 = 1.625
+    const result = estimateTempoFromOnsets([0, 0.5, 1.0, 1.5, 6.5]);
+    expect(result?.bpm).toBeCloseTo(120, 5); // median gives 120, mean would give ~37
+  });
+});
+
+// ---------------------------------------------------------------------------
+// measureSwingRatio
+// ---------------------------------------------------------------------------
+
+describe('measureSwingRatio', () => {
+  it('returns null for fewer than 3 events (< subBeats+1)', () => {
+    expect(measureSwingRatio([])).toBeNull();
+    expect(measureSwingRatio([makeEvent(0)])).toBeNull();
+    expect(measureSwingRatio([makeEvent(0), makeEvent(0.5)])).toBeNull();
+  });
+
+  it('returns 1.0 for straight 8th notes (no swing)', () => {
+    // 4 evenly-spaced events: 0, 0.25, 0.5, 0.75
+    // group [0, 0.25, 0.5]: long=0.25, short=0.25, ratio=1.0
+    // group [0.5, 0.75, ...] needs 3 events; only one full group
+    const result = measureSwingRatio([makeEvent(0), makeEvent(0.25), makeEvent(0.5)]);
+    expect(result).toBeCloseTo(1.0, 8);
+  });
+
+  it('returns 2.0 for 2:1 swing (triplet swing)', () => {
+    // Beat group: long = 2/3 of beat, short = 1/3 of beat
+    // onset at 0, 2/3, 1, 5/3, 2...
+    // ratio = (2/3) / (1/3) = 2.0
+    const third = 1 / 3;
+    const events = [
+      makeEvent(0),
+      makeEvent(2 * third),
+      makeEvent(1),
+      makeEvent(1 + 2 * third),
+      makeEvent(2),
+    ];
+    const result = measureSwingRatio(events);
+    expect(result).not.toBeNull();
+    expect(result!).toBeCloseTo(2.0, 5);
+  });
+
+  it('handles unsorted events by sorting internally', () => {
+    // Same as straight 8th notes test but shuffled
+    const result = measureSwingRatio([makeEvent(0.5), makeEvent(0), makeEvent(0.25)]);
+    expect(result).toBeCloseTo(1.0, 8);
+  });
+
+  it('throws RangeError for non-finite onset', () => {
+    expect(() => measureSwingRatio([makeEvent(0), makeEvent(NaN), makeEvent(0.5)])).toThrow(
+      RangeError,
+    );
+  });
+
+  it('throws RangeError for non-integer subBeatsPerBeat', () => {
+    expect(() =>
+      measureSwingRatio([makeEvent(0), makeEvent(0.25), makeEvent(0.5)], { subBeatsPerBeat: 1.5 }),
+    ).toThrow(RangeError);
+  });
+
+  it('throws RangeError for subBeatsPerBeat < 1', () => {
+    expect(() =>
+      measureSwingRatio([makeEvent(0), makeEvent(0.25), makeEvent(0.5)], { subBeatsPerBeat: 0 }),
+    ).toThrow(RangeError);
+  });
+
+  it('returns null when all short intervals are zero or negative (degenerate)', () => {
+    // Duplicate onset times within a beat group
+    const result = measureSwingRatio([makeEvent(0), makeEvent(0), makeEvent(0)]);
+    expect(result).toBeNull();
+  });
+});

--- a/src/performance-timing/performance-timing.ts
+++ b/src/performance-timing/performance-timing.ts
@@ -1,0 +1,582 @@
+/**
+ * Performance timing analysis: quantization, comparison, and tempo estimation.
+ *
+ * All functions are pure computations over numbers / {@link PerformedEvent}
+ * arrays. No I/O, no timers, no onset detection.
+ *
+ * Conventions
+ * -----------
+ * - "error" always means `performedOnset − expectedOnset` (positive ⇒ late).
+ * - `latencyOffsetSeconds` is SUBTRACTED from performed onsets before any
+ *   comparison (corrects for known input-device delay).
+ * - Quantized deviations are preserved, not discarded (humanized timing).
+ */
+
+import type { Sequence } from '../sequences/sequence.js';
+import type {
+  PerformedEvent,
+  QuantizedPerformance,
+  QuantizedEvent,
+  TimingComparison,
+  TimingEvent,
+  MissedTimingEvent,
+  ExtraTimingEvent,
+  TimingErrorClass,
+  CompareTimingOptions,
+  TempoEstimate,
+  EstimateTempoOptions,
+  MeasureSwingOptions,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function requireFinitePositive(value: number, label: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(`${label} must be a finite positive number, received ${value}.`);
+  }
+}
+
+function requireFiniteNonNegative(value: number, label: string): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${label} must be a finite non-negative number, received ${value}.`);
+  }
+}
+
+function requireFinite(value: number, label: string): void {
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`${label} must be a finite number, received ${value}.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// quantizePerformance
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link quantizePerformance}.
+ */
+export type QuantizeOptions = {
+  /**
+   * A signed offset (in seconds) to apply before snapping to the grid.
+   * Useful for swing or global latency correction at the quantization step.
+   * Default `0`.
+   */
+  readonly offsetSeconds?: number;
+};
+
+/**
+ * Snaps each performed onset to the nearest multiple of `gridSeconds`,
+ * preserving the signed humanized-timing deviation as
+ * `originalOnsetSeconds − quantizedOnsetSeconds`.
+ *
+ * A swing/latency `offsetSeconds` shifts all onsets before grid-snapping
+ * (e.g. `−0.01` pulls a performer's notes slightly earlier on the grid).
+ * The offset is recorded in the returned {@link QuantizedPerformance}.
+ *
+ * @param events The performed events to quantize.
+ * @param gridSeconds The grid interval in seconds (must be finite and positive).
+ * @param options Optional offset.
+ * @returns The quantized performance with per-event deviations.
+ * @throws {RangeError} When `gridSeconds` is not a finite positive number.
+ * @throws {RangeError} When any onset is not a finite number.
+ */
+export function quantizePerformance(
+  events: readonly PerformedEvent[],
+  gridSeconds: number,
+  options?: QuantizeOptions,
+): QuantizedPerformance {
+  requireFinitePositive(gridSeconds, 'gridSeconds');
+
+  const offset = options?.offsetSeconds ?? 0;
+  requireFinite(offset, 'offsetSeconds');
+
+  const quantizedEvents: QuantizedEvent[] = events.map((event) => {
+    requireFinite(event.onsetSeconds, 'onsetSeconds');
+
+    const shifted = event.onsetSeconds + offset;
+    const quantized = Math.round(shifted / gridSeconds) * gridSeconds;
+    const deviation = event.onsetSeconds - quantized;
+
+    let result: QuantizedEvent = {
+      originalOnsetSeconds: event.onsetSeconds,
+      quantizedOnsetSeconds: quantized,
+      deviationSeconds: deviation,
+    };
+
+    if (event.durationSeconds !== undefined) {
+      result = { ...result, durationSeconds: event.durationSeconds };
+    }
+
+    if (event.note !== undefined) {
+      result = { ...result, note: event.note };
+    }
+
+    if (event.velocity !== undefined) {
+      result = { ...result, velocity: event.velocity };
+    }
+
+    return result;
+  });
+
+  return {
+    gridSeconds,
+    offsetSeconds: offset,
+    events: Object.freeze(quantizedEvents),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// classifyTimingError
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link classifyTimingError}.
+ */
+export type ClassifyTimingOptions = {
+  /**
+   * Half-width of the on-time window in seconds. Default `0.05` (50 ms).
+   * An absolute error ≤ toleranceSeconds is classified 'on-time'.
+   */
+  readonly toleranceSeconds?: number;
+};
+
+/**
+ * Classifies a single timing error (performed − expected) as 'on-time',
+ * 'early', or 'late'.
+ *
+ * - |errorSeconds| ≤ toleranceSeconds ⇒ `'on-time'`
+ * - errorSeconds < −toleranceSeconds ⇒ `'early'` (played before the beat)
+ * - errorSeconds > toleranceSeconds ⇒ `'late'` (played after the beat)
+ *
+ * @param errorSeconds Signed error: `performedOnset − expectedOnset`.
+ * @param options Tolerance window.
+ * @returns The classification.
+ * @throws {RangeError} When `toleranceSeconds` is negative or non-finite.
+ * @throws {RangeError} When `errorSeconds` is not finite.
+ */
+export function classifyTimingError(
+  errorSeconds: number,
+  options?: ClassifyTimingOptions,
+): TimingErrorClass {
+  requireFinite(errorSeconds, 'errorSeconds');
+
+  const tolerance = options?.toleranceSeconds ?? 0.05;
+  requireFiniteNonNegative(tolerance, 'toleranceSeconds');
+
+  const absError = Math.abs(errorSeconds);
+
+  if (absError <= tolerance) return 'on-time';
+  if (errorSeconds < 0) return 'early';
+  return 'late';
+}
+
+// ---------------------------------------------------------------------------
+// comparePerformanceTiming — matching helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract expected onset times from either a plain number array or a Sequence.
+ * For Sequence inputs, only note and chord events contribute expected onsets
+ * (rests cannot be "played").
+ */
+function isNumberArray(value: readonly number[] | Sequence): value is readonly number[] {
+  return Array.isArray(value);
+}
+
+function extractExpectedOnsets(expected: readonly number[] | Sequence): readonly number[] {
+  if (isNumberArray(expected)) {
+    return expected;
+  }
+
+  // Sequence branch — call toAbsoluteSeconds and keep note/chord starts only.
+  const timedEvents = expected.toAbsoluteSeconds();
+
+  const onsets: number[] = [];
+
+  for (const event of timedEvents) {
+    if (event.type === 'note' || event.type === 'chord') {
+      onsets.push(event.startSeconds);
+    }
+  }
+
+  return onsets;
+}
+
+/**
+ * Greedy nearest-neighbor matching between expected and performed onset lists.
+ * Returns pairs as `[expectedIndex, performedIndex]` sorted by ascending
+ * absolute distance. Each index appears at most once.
+ */
+function nearestNeighborMatch(
+  expected: readonly number[],
+  performed: readonly number[],
+): Array<[number, number]> {
+  // Build all candidate pairs with their distances.
+  type Candidate = { dist: number; ei: number; pi: number };
+  const candidates: Candidate[] = [];
+
+  for (let ei = 0; ei < expected.length; ei++) {
+    const exp = expected[ei];
+
+    if (exp === undefined) continue;
+
+    for (let pi = 0; pi < performed.length; pi++) {
+      const perf = performed[pi];
+
+      if (perf === undefined) continue;
+
+      candidates.push({ dist: Math.abs(perf - exp), ei, pi });
+    }
+  }
+
+  // Sort ascending by distance so closest pairs are assigned first.
+  candidates.sort((a, b) => a.dist - b.dist);
+
+  const usedExpected = new Set<number>();
+  const usedPerformed = new Set<number>();
+  const result: Array<[number, number]> = [];
+
+  for (const { ei, pi } of candidates) {
+    if (usedExpected.has(ei) || usedPerformed.has(pi)) continue;
+
+    usedExpected.add(ei);
+    usedPerformed.add(pi);
+    result.push([ei, pi]);
+  }
+
+  return result;
+}
+
+type MatchAccumulator = {
+  events: TimingEvent[];
+  onTimeCount: number;
+  earlyCount: number;
+  lateCount: number;
+  matchedExpected: Set<number>;
+  matchedPerformed: Set<number>;
+};
+
+/**
+ * Processes all matched pairs and appends MatchedTimingEvent records to the accumulator.
+ */
+function processMatchedPairs(
+  pairs: Array<[number, number]>,
+  expectedOnsets: readonly number[],
+  adjustedPerformed: readonly number[],
+  performed: readonly PerformedEvent[],
+  tolerance: number,
+  acc: MatchAccumulator,
+): void {
+  for (const [ei, pi] of pairs) {
+    const exp = expectedOnsets[ei];
+    const perf = adjustedPerformed[pi];
+    const originalEvent = performed[pi];
+
+    if (exp === undefined || perf === undefined || originalEvent === undefined) continue;
+
+    acc.matchedExpected.add(ei);
+    acc.matchedPerformed.add(pi);
+
+    const errorSeconds = perf - exp;
+    const classification = classifyTimingError(errorSeconds, { toleranceSeconds: tolerance });
+
+    if (classification === 'on-time') acc.onTimeCount++;
+    else if (classification === 'early') acc.earlyCount++;
+    else acc.lateCount++;
+
+    acc.events.push({
+      type: 'matched',
+      expectedOnsetSeconds: exp,
+      performedOnsetSeconds: perf,
+      errorSeconds,
+      classification,
+      event: originalEvent,
+    });
+  }
+}
+
+/**
+ * Appends MissedTimingEvent records for expected onsets without a match.
+ */
+function collectMissedEvents(
+  expectedOnsets: readonly number[],
+  matchedExpected: ReadonlySet<number>,
+  events: TimingEvent[],
+): void {
+  for (let ei = 0; ei < expectedOnsets.length; ei++) {
+    if (matchedExpected.has(ei)) continue;
+
+    const exp = expectedOnsets[ei];
+
+    if (exp === undefined) continue;
+
+    const missed: MissedTimingEvent = { type: 'missed', expectedOnsetSeconds: exp };
+    events.push(missed);
+  }
+}
+
+/**
+ * Appends ExtraTimingEvent records for performed onsets without a match.
+ */
+function collectExtraEvents(
+  adjustedPerformed: readonly number[],
+  performed: readonly PerformedEvent[],
+  matchedPerformed: ReadonlySet<number>,
+  events: TimingEvent[],
+): void {
+  for (let pi = 0; pi < adjustedPerformed.length; pi++) {
+    if (matchedPerformed.has(pi)) continue;
+
+    const perf = adjustedPerformed[pi];
+    const originalEvent = performed[pi];
+
+    if (perf === undefined || originalEvent === undefined) continue;
+
+    const extra: ExtraTimingEvent = {
+      type: 'extra',
+      performedOnsetSeconds: perf,
+      event: originalEvent,
+    };
+
+    events.push(extra);
+  }
+}
+
+/**
+ * Compares a live (or recorded) performance against an expected onset grid or
+ * {@link Sequence}, returning per-event classification and aggregate counts.
+ *
+ * Matching strategy: nearest-neighbor greedy assignment (closest expected–
+ * performed pairs are matched first). The `toleranceSeconds` parameter only
+ * affects the early/late/on-time label — it does NOT restrict the match window.
+ * Unmatched expected onsets are reported as `'missed'`; unmatched performed
+ * onsets are `'extra'`.
+ *
+ * A known input latency (`latencyOffsetSeconds`) is subtracted from each
+ * performed onset before matching and classification. The adjusted onset is
+ * what appears in `performedOnsetSeconds` on each result record.
+ *
+ * For {@link Sequence} inputs, only note and chord events contribute expected
+ * onsets (rests cannot be performed).
+ *
+ * @param expected Array of expected onset times (seconds) or a {@link Sequence}.
+ * @param performed The performed events.
+ * @param options Tolerance and latency offset.
+ * @returns Full timing comparison with per-event breakdown and aggregate counts.
+ * @throws {RangeError} When `toleranceSeconds` is negative or non-finite.
+ * @throws {RangeError} When `latencyOffsetSeconds` is non-finite.
+ * @throws {RangeError} When any onset is non-finite.
+ */
+export function comparePerformanceTiming(
+  expected: readonly number[] | Sequence,
+  performed: readonly PerformedEvent[],
+  options?: CompareTimingOptions,
+): TimingComparison {
+  const tolerance = options?.toleranceSeconds ?? 0.05;
+  requireFiniteNonNegative(tolerance, 'toleranceSeconds');
+
+  const latency = options?.latencyOffsetSeconds ?? 0;
+  requireFinite(latency, 'latencyOffsetSeconds');
+
+  const expectedOnsets = extractExpectedOnsets(expected);
+
+  for (const onset of expectedOnsets) {
+    requireFinite(onset, 'expected onset');
+  }
+
+  const adjustedPerformed: number[] = performed.map((event) => {
+    requireFinite(event.onsetSeconds, 'performed onset');
+    return event.onsetSeconds - latency;
+  });
+
+  const pairs = nearestNeighborMatch(expectedOnsets, adjustedPerformed);
+
+  const acc: MatchAccumulator = {
+    events: [],
+    onTimeCount: 0,
+    earlyCount: 0,
+    lateCount: 0,
+    matchedExpected: new Set<number>(),
+    matchedPerformed: new Set<number>(),
+  };
+
+  processMatchedPairs(pairs, expectedOnsets, adjustedPerformed, performed, tolerance, acc);
+  collectMissedEvents(expectedOnsets, acc.matchedExpected, acc.events);
+  collectExtraEvents(adjustedPerformed, performed, acc.matchedPerformed, acc.events);
+
+  return {
+    events: Object.freeze(acc.events),
+    onTimeCount: acc.onTimeCount,
+    earlyCount: acc.earlyCount,
+    lateCount: acc.lateCount,
+    missedCount: expectedOnsets.length - acc.matchedExpected.size,
+    extraCount: adjustedPerformed.length - acc.matchedPerformed.size,
+    latencyOffsetSeconds: latency,
+    toleranceSeconds: tolerance,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// estimateTempoFromOnsets
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the median of a non-empty array of numbers.
+ */
+function median(values: number[]): number {
+  const sorted = values.toSorted((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 1) {
+    const val = sorted[mid];
+    return val !== undefined ? val : 0;
+  }
+
+  const lo = sorted[mid - 1];
+  const hi = sorted[mid];
+  return lo !== undefined && hi !== undefined ? (lo + hi) / 2 : 0;
+}
+
+/**
+ * Derives a BPM estimate from a sequence of onset timestamps using the
+ * median inter-onset interval (IOI).
+ *
+ * `bpm = 60 / (medianIOI / beatsPerInterval)`
+ *
+ * Returns `null` for fewer than 2 onsets (no IOI can be computed).
+ *
+ * @param onsets Onset times in seconds, in any order (they are sorted internally).
+ * @param options `beatsPerInterval` — how many beats each IOI represents (default `1`).
+ * @returns A {@link TempoEstimate} or `null` when fewer than 2 onsets are provided.
+ * @throws {RangeError} When any onset is non-finite.
+ * @throws {RangeError} When `beatsPerInterval` is not a finite positive number.
+ * @throws {RangeError} When any inter-onset interval is zero or negative (unsorted/duplicate onsets).
+ */
+export function estimateTempoFromOnsets(
+  onsets: readonly number[],
+  options?: EstimateTempoOptions,
+): TempoEstimate | null {
+  if (onsets.length < 2) return null;
+
+  for (const onset of onsets) {
+    requireFinite(onset, 'onset');
+  }
+
+  const beatsPerInterval = options?.beatsPerInterval ?? 1;
+  requireFinitePositive(beatsPerInterval, 'beatsPerInterval');
+
+  const sorted = onsets.toSorted((a, b) => a - b);
+  const iois: number[] = [];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1];
+    const curr = sorted[i];
+
+    if (prev === undefined || curr === undefined) continue;
+
+    const ioi = curr - prev;
+
+    if (ioi <= 0) {
+      throw new RangeError(
+        `Inter-onset interval must be positive (check for duplicate or unsorted onsets), received ${ioi}.`,
+      );
+    }
+
+    iois.push(ioi);
+  }
+
+  const medianIoi = median(iois);
+  const secondsPerBeat = medianIoi / beatsPerInterval;
+  const bpm = 60 / secondsPerBeat;
+
+  return {
+    bpm,
+    medianInterOnsetSeconds: medianIoi,
+    intervalCount: iois.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// measureSwingRatio (optional)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates subBeatsPerBeat option and throws if invalid.
+ */
+function validateSubBeats(subBeats: number): void {
+  if (!Number.isInteger(subBeats) || subBeats < 1) {
+    throw new RangeError(`subBeatsPerBeat must be a positive integer, received ${subBeats}.`);
+  }
+}
+
+/**
+ * Collects swing ratios from sorted onset times in beat groups of `subBeats`.
+ * Skips groups where the short interval is non-positive.
+ */
+function collectSwingRatios(onsets: readonly number[], subBeats: number): number[] {
+  const ratios: number[] = [];
+
+  for (let i = 0; i + subBeats < onsets.length; i += subBeats) {
+    const first = onsets[i];
+    const second = onsets[i + 1];
+    const groupEnd = onsets[i + subBeats];
+
+    if (first === undefined || second === undefined || groupEnd === undefined) continue;
+
+    const longInterval = second - first;
+    const shortInterval = groupEnd - second;
+
+    if (shortInterval <= 0) continue;
+
+    ratios.push(longInterval / shortInterval);
+  }
+
+  return ratios;
+}
+
+/**
+ * Estimates a swing ratio from a sequence of performed onsets.
+ *
+ * Swing in jazz is typically expressed as a ratio of a long first 8th note
+ * to a short second 8th note within each beat pair. This function pairs
+ * consecutive onsets into beat groups of `subBeatsPerBeat` (default `2`),
+ * then returns the mean ratio of the first sub-beat duration to the second.
+ *
+ * A perfectly straight feel returns `1.0`. A 2:1 swing returns `2.0`.
+ *
+ * Returns `null` when there are fewer than `subBeatsPerBeat + 1` onsets
+ * (not enough data for even one complete beat pair), or when all short
+ * intervals within groups are zero or negative (degenerate input).
+ *
+ * @param events Performed events whose onsets define the rhythm.
+ * @param options `subBeatsPerBeat` — number of sub-beats per beat pair (default `2`).
+ * @returns Mean swing ratio or `null` for insufficient data.
+ * @throws {RangeError} When any onset is non-finite.
+ * @throws {RangeError} When `subBeatsPerBeat` is not a finite positive integer.
+ */
+export function measureSwingRatio(
+  events: readonly PerformedEvent[],
+  options?: MeasureSwingOptions,
+): number | null {
+  const subBeats = options?.subBeatsPerBeat ?? 2;
+  validateSubBeats(subBeats);
+
+  for (const event of events) {
+    requireFinite(event.onsetSeconds, 'onsetSeconds');
+  }
+
+  const onsets = events
+    .toSorted((a, b) => a.onsetSeconds - b.onsetSeconds)
+    .map((e) => e.onsetSeconds);
+
+  if (onsets.length < subBeats + 1) return null;
+
+  const ratios = collectSwingRatios(onsets, subBeats);
+
+  if (ratios.length === 0) return null;
+
+  const sum = ratios.reduce((acc, r) => acc + r, 0);
+  return sum / ratios.length;
+}

--- a/src/performance-timing/types.ts
+++ b/src/performance-timing/types.ts
@@ -1,0 +1,209 @@
+/**
+ * Domain types for performance-timing analysis.
+ *
+ * All types are pure data (no class instances). Domain-specific types live
+ * next to the module — there is no shared root types file.
+ */
+
+import type { Note } from '../note.js';
+
+// ---------------------------------------------------------------------------
+// PerformedEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * A single event captured from a live (or recorded) musical performance.
+ * Only `onsetSeconds` is required; the remaining fields are optional context.
+ */
+export type PerformedEvent = {
+  /** The wall-clock time (in seconds) at which the event was triggered. */
+  readonly onsetSeconds: number;
+  /** How long the event was held, in seconds. Optional. */
+  readonly durationSeconds?: number;
+  /** The note that was played, if known. */
+  readonly note?: Note;
+  /** MIDI velocity (0..127), if available. */
+  readonly velocity?: number;
+};
+
+// ---------------------------------------------------------------------------
+// TimingError classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classification of a single event's timing relative to an expected onset.
+ * - `'on-time'`: |error| ≤ toleranceSeconds
+ * - `'early'`: error < −toleranceSeconds (played before the expected onset)
+ * - `'late'`: error > toleranceSeconds (played after the expected onset)
+ */
+export type TimingErrorClass = 'early' | 'late' | 'on-time';
+
+// ---------------------------------------------------------------------------
+// QuantizedPerformance
+// ---------------------------------------------------------------------------
+
+/**
+ * A single event after grid-quantization.
+ */
+export type QuantizedEvent = {
+  /** The original onset time from the source {@link PerformedEvent}. */
+  readonly originalOnsetSeconds: number;
+  /** The nearest grid position (multiple of gridSeconds). */
+  readonly quantizedOnsetSeconds: number;
+  /**
+   * Signed deviation: `originalOnsetSeconds − quantizedOnsetSeconds`.
+   * Positive means the player was late relative to the grid; negative means early.
+   */
+  readonly deviationSeconds: number;
+  /** Pass-through of the source event's optional fields. */
+  readonly durationSeconds?: number;
+  /** Pass-through of the source event's optional note. */
+  readonly note?: Note;
+  /** Pass-through of the source event's optional velocity. */
+  readonly velocity?: number;
+};
+
+/**
+ * The result of {@link quantizePerformance}: each performed onset snapped to
+ * the nearest grid position, with the signed humanized-timing deviation preserved.
+ */
+export type QuantizedPerformance = {
+  /** The grid interval used for quantization, in seconds. */
+  readonly gridSeconds: number;
+  /** A swing/latency offset that was applied before quantization (0 if none). */
+  readonly offsetSeconds: number;
+  /** The quantized events in the same order as the input. */
+  readonly events: readonly QuantizedEvent[];
+};
+
+// ---------------------------------------------------------------------------
+// TimingComparison
+// ---------------------------------------------------------------------------
+
+/**
+ * A performed onset successfully matched to an expected onset.
+ */
+export type MatchedTimingEvent = {
+  /** Discriminant. */
+  readonly type: 'matched';
+  /** Expected onset time in seconds (after any latency correction on the performed side). */
+  readonly expectedOnsetSeconds: number;
+  /** Performed onset time in seconds (after latency offset subtraction). */
+  readonly performedOnsetSeconds: number;
+  /**
+   * Signed timing error: `performedOnsetSeconds − expectedOnsetSeconds`.
+   * Positive ⇒ late; negative ⇒ early.
+   */
+  readonly errorSeconds: number;
+  /** Classification of the timing error using the provided tolerance. */
+  readonly classification: TimingErrorClass;
+  /** The original {@link PerformedEvent} that produced this match. */
+  readonly event: PerformedEvent;
+};
+
+/**
+ * An expected onset that had no matching performed onset.
+ */
+export type MissedTimingEvent = {
+  /** Discriminant. */
+  readonly type: 'missed';
+  /** The expected onset time that was not performed. */
+  readonly expectedOnsetSeconds: number;
+};
+
+/**
+ * A performed onset that had no matching expected onset.
+ */
+export type ExtraTimingEvent = {
+  /** Discriminant. */
+  readonly type: 'extra';
+  /** The performed onset time (after latency offset subtraction). */
+  readonly performedOnsetSeconds: number;
+  /** The original {@link PerformedEvent}. */
+  readonly event: PerformedEvent;
+};
+
+/**
+ * A union of all per-event comparison results.
+ */
+export type TimingEvent = MatchedTimingEvent | MissedTimingEvent | ExtraTimingEvent;
+
+/**
+ * Options for {@link comparePerformanceTiming}.
+ */
+export type CompareTimingOptions = {
+  /**
+   * Half-width of the on-time window, in seconds. Default `0.05` (50 ms).
+   * An |error| ≤ toleranceSeconds is classified 'on-time'.
+   */
+  readonly toleranceSeconds?: number;
+  /**
+   * Known input latency, in seconds. Subtracted from each performed onset
+   * before matching. Default `0`.
+   */
+  readonly latencyOffsetSeconds?: number;
+};
+
+/**
+ * Full result of {@link comparePerformanceTiming}.
+ */
+export type TimingComparison = {
+  /** Per-event breakdown (matched, missed, and extra events). */
+  readonly events: readonly TimingEvent[];
+  /** Number of events classified 'on-time'. */
+  readonly onTimeCount: number;
+  /** Number of events classified 'early'. */
+  readonly earlyCount: number;
+  /** Number of events classified 'late'. */
+  readonly lateCount: number;
+  /** Number of expected onsets with no matching performed event. */
+  readonly missedCount: number;
+  /** Number of performed onsets with no matching expected event. */
+  readonly extraCount: number;
+  /** Latency offset actually applied (0 if not provided). */
+  readonly latencyOffsetSeconds: number;
+  /** Tolerance actually used. */
+  readonly toleranceSeconds: number;
+};
+
+// ---------------------------------------------------------------------------
+// TempoEstimate
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link estimateTempoFromOnsets}.
+ */
+export type EstimateTempoOptions = {
+  /**
+   * Number of beats each inter-onset interval represents. Default `1`
+   * (each onset is one beat). Use `2` if each onset is a half note, etc.
+   */
+  readonly beatsPerInterval?: number;
+};
+
+/**
+ * Result of {@link estimateTempoFromOnsets}.
+ */
+export type TempoEstimate = {
+  /** Estimated tempo in BPM. */
+  readonly bpm: number;
+  /** The median inter-onset interval used for the BPM derivation, in seconds. */
+  readonly medianInterOnsetSeconds: number;
+  /** Number of inter-onset intervals analyzed. */
+  readonly intervalCount: number;
+};
+
+// ---------------------------------------------------------------------------
+// MeasureSwingOptions
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link measureSwingRatio}.
+ */
+export type MeasureSwingOptions = {
+  /**
+   * Expected number of sub-beats per beat pair for swing analysis. Default `2`
+   * (standard 8th-note swing: two 8th notes per beat).
+   */
+  readonly subBeatsPerBeat?: number;
+};

--- a/src/pitch/index.ts
+++ b/src/pitch/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Pitch-estimate scoring helpers.
+ *
+ * A pure scoring layer over an application-provided pitch estimate.
+ * Does NOT perform pitch detection or access any microphone.
+ *
+ * Import as `octavian/pitch` (subpath export — not part of the root barrel).
+ */
+
+export { evaluatePitchEstimate } from './pitch-estimate.js';
+
+export type {
+  PitchEstimate,
+  PitchEvaluation,
+  EvaluatePitchEstimateOptions,
+} from './pitch-estimate.js';

--- a/src/pitch/pitch-estimate.test.ts
+++ b/src/pitch/pitch-estimate.test.ts
@@ -212,24 +212,6 @@ describe('evaluatePitchEstimate', () => {
     });
   });
 
-  describe('clarity field (pass-through)', () => {
-    it('accepts and ignores clarity without error', () => {
-      const result = evaluatePitchEstimate(
-        { frequency: A4_FREQ, clarity: 0.95 },
-        { note: 'A', octave: 4 },
-      );
-
-      // clarity does not affect the result — just make sure it does not throw
-      expect(result.centsError).toBeCloseTo(0, 6);
-    });
-
-    it('accepts estimates with no clarity field', () => {
-      const result = evaluatePitchEstimate({ frequency: A4_FREQ }, { note: 'A', octave: 4 });
-
-      expect(result.withinTolerance).toBe(true);
-    });
-  });
-
   describe('default options', () => {
     it('defaults to 50-cent tolerance (boundary at exactly 50 cents)', () => {
       // 50 cents sharp from A4 is exactly the semitone midpoint; it rounds to
@@ -308,6 +290,36 @@ describe('evaluatePitchEstimate', () => {
       expect(() =>
         evaluatePitchEstimate({ frequency: A4_FREQ }, 'NotAValidNoteName' as never),
       ).toThrow(TypeError);
+    });
+
+    it('throws RangeError for negative centsTolerance', () => {
+      expect(() =>
+        evaluatePitchEstimate(
+          { frequency: A4_FREQ },
+          { note: 'A', octave: 4 },
+          { centsTolerance: -1 },
+        ),
+      ).toThrow(RangeError);
+    });
+
+    it('throws RangeError for NaN centsTolerance', () => {
+      expect(() =>
+        evaluatePitchEstimate(
+          { frequency: A4_FREQ },
+          { note: 'A', octave: 4 },
+          { centsTolerance: NaN },
+        ),
+      ).toThrow(RangeError);
+    });
+
+    it('throws RangeError for Infinity centsTolerance', () => {
+      expect(() =>
+        evaluatePitchEstimate(
+          { frequency: A4_FREQ },
+          { note: 'A', octave: 4 },
+          { centsTolerance: Infinity },
+        ),
+      ).toThrow(RangeError);
     });
   });
 });

--- a/src/pitch/pitch-estimate.test.ts
+++ b/src/pitch/pitch-estimate.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'bun:test';
+import { evaluatePitchEstimate } from './index.js';
+import { Note } from '../note.js';
+import { createFrequency } from '../branded-types.js';
+import type { Tuning } from '../tuning.js';
+
+// ---------------------------------------------------------------------------
+// Tuning fixture for alternate-tuning tests (A4 = 432 Hz)
+// ---------------------------------------------------------------------------
+
+const TUNING_432: Tuning = {
+  reference: 'A4',
+  frequency: createFrequency(432),
+};
+
+// ---------------------------------------------------------------------------
+// Exact equal-tempered frequencies (verified externally)
+// ---------------------------------------------------------------------------
+
+// A4 = 440 Hz
+const A4_FREQ = 440;
+// A#4 = 466.1637615180899 Hz
+const AS4_FREQ = 466.1637615180899;
+// A5 = 880 Hz
+const A5_FREQ = 880;
+// G#4 = 415.3046975799451 Hz
+const GS4_FREQ = 415.3046975799451;
+
+describe('evaluatePitchEstimate', () => {
+  describe('A4 target at standard tuning (440 Hz)', () => {
+    it('returns 0 centsError when estimate equals target frequency exactly', () => {
+      const result = evaluatePitchEstimate({ frequency: A4_FREQ }, { note: 'A', octave: 4 });
+
+      expect(result.centsError).toBeCloseTo(0, 6);
+      expect(result.nearestNote.note).toBe('A');
+      expect(result.nearestNote.octave).toBe(4);
+      expect(result.pitchClassMatches).toBe(true);
+      expect(result.registerMatches).toBe(true);
+      expect(result.likelyOctaveError).toBe(false);
+      expect(result.withinTolerance).toBe(true);
+    });
+
+    it('returns ~+100 cents when estimate is A#4 (sharp)', () => {
+      const result = evaluatePitchEstimate({ frequency: AS4_FREQ }, { note: 'A', octave: 4 });
+
+      // ~100 cents sharp
+      expect(result.centsError).toBeCloseTo(100, 1);
+      // Nearest note is A#4, not A4
+      expect(result.nearestNote.note).toBe('A#');
+      expect(result.nearestNote.octave).toBe(4);
+      expect(result.pitchClassMatches).toBe(false);
+      expect(result.registerMatches).toBe(false);
+      expect(result.likelyOctaveError).toBe(false);
+      expect(result.withinTolerance).toBe(false);
+    });
+
+    it('returns ~-100 cents when estimate is G#4 (flat)', () => {
+      const result = evaluatePitchEstimate({ frequency: GS4_FREQ }, { note: 'A', octave: 4 });
+
+      // ~-100 cents flat
+      expect(result.centsError).toBeCloseTo(-100, 1);
+      expect(result.nearestNote.note).toBe('G#');
+      expect(result.nearestNote.octave).toBe(4);
+      expect(result.pitchClassMatches).toBe(false);
+      expect(result.registerMatches).toBe(false);
+      expect(result.likelyOctaveError).toBe(false);
+      expect(result.withinTolerance).toBe(false);
+    });
+
+    it('detects likelyOctaveError when estimate is A5 (880 Hz)', () => {
+      const result = evaluatePitchEstimate({ frequency: A5_FREQ }, { note: 'A', octave: 4 });
+
+      // +1200 cents (one octave sharp)
+      expect(result.centsError).toBeCloseTo(1200, 1);
+      expect(result.nearestNote.note).toBe('A');
+      expect(result.nearestNote.octave).toBe(5);
+      expect(result.pitchClassMatches).toBe(true);
+      expect(result.registerMatches).toBe(false);
+      expect(result.likelyOctaveError).toBe(true);
+      expect(result.withinTolerance).toBe(false);
+    });
+
+    it('handles near-boundary estimate of ~453 Hz (~+50.4 cents above A4)', () => {
+      const result = evaluatePitchEstimate({ frequency: 453 }, { note: 'A', octave: 4 });
+
+      // 50.4 cents above A4; nearest note is A#4 (not A4)
+      expect(result.centsError).toBeCloseTo(50.4, 1);
+      expect(result.nearestNote.note).toBe('A#');
+      expect(result.nearestNote.octave).toBe(4);
+      expect(result.pitchClassMatches).toBe(false);
+      expect(result.registerMatches).toBe(false);
+      expect(result.likelyOctaveError).toBe(false);
+      // 50.4 > 50, so just outside default tolerance
+      expect(result.withinTolerance).toBe(false);
+    });
+
+    it('is within tolerance when estimate is within 50 cents (sharp)', () => {
+      // 20 cents sharp: 440 * 2^(20/1200)
+      const sharpBy20 = A4_FREQ * Math.pow(2, 20 / 1200);
+      const result = evaluatePitchEstimate({ frequency: sharpBy20 }, { note: 'A', octave: 4 });
+
+      expect(result.centsError).toBeCloseTo(20, 1);
+      expect(result.withinTolerance).toBe(true);
+    });
+
+    it('respects custom centsTolerance', () => {
+      // 30 cents sharp — within tolerance=50, outside tolerance=25
+      const sharpBy30 = A4_FREQ * Math.pow(2, 30 / 1200);
+      const tight = evaluatePitchEstimate(
+        { frequency: sharpBy30 },
+        { note: 'A', octave: 4 },
+        { centsTolerance: 25 },
+      );
+      const loose = evaluatePitchEstimate(
+        { frequency: sharpBy30 },
+        { note: 'A', octave: 4 },
+        { centsTolerance: 50 },
+      );
+
+      expect(tight.withinTolerance).toBe(false);
+      expect(loose.withinTolerance).toBe(true);
+    });
+  });
+
+  describe('alternate tuning: A4 = 432 Hz', () => {
+    it('returns 0 centsError when estimate equals 432 under 432 tuning', () => {
+      const result = evaluatePitchEstimate(
+        { frequency: 432 },
+        { note: 'A', octave: 4 },
+        { tuning: TUNING_432 },
+      );
+
+      expect(result.centsError).toBeCloseTo(0, 6);
+      expect(result.nearestNote.note).toBe('A');
+      expect(result.nearestNote.octave).toBe(4);
+      expect(result.withinTolerance).toBe(true);
+    });
+
+    it('shows positive cents error when 440 is given but target is A4 at 432 tuning', () => {
+      // Under 432 tuning, A4 target frequency is 432 Hz — estimate 440 is sharp
+      const result = evaluatePitchEstimate(
+        { frequency: 440 },
+        { note: 'A', octave: 4 },
+        { tuning: TUNING_432 },
+      );
+
+      // 440 / 432 = ~31.8 cents sharp
+      const expectedCents = 1200 * Math.log2(440 / 432);
+
+      expect(result.centsError).toBeCloseTo(expectedCents, 4);
+      expect(result.centsError).toBeGreaterThan(0);
+    });
+  });
+
+  describe('pitchClassOnly mode', () => {
+    it('withinTolerance is true for exact pitch match regardless of octave', () => {
+      // A5 = 880 Hz with target A4 — octave error, but pitch class matches
+      // Folded centsError of 1200 => 0 cents in pitch-class space
+      const result = evaluatePitchEstimate(
+        { frequency: A5_FREQ },
+        { note: 'A', octave: 4 },
+        { pitchClassOnly: true },
+      );
+
+      expect(result.likelyOctaveError).toBe(true);
+      expect(result.withinTolerance).toBe(true);
+    });
+
+    it('withinTolerance is false for A#4 estimate vs A4 target with default tolerance', () => {
+      // +100 cents folds to 100; |100| > 50
+      const result = evaluatePitchEstimate(
+        { frequency: AS4_FREQ },
+        { note: 'A', octave: 4 },
+        { pitchClassOnly: true },
+      );
+
+      expect(result.withinTolerance).toBe(false);
+    });
+
+    it('withinTolerance is true for A#4 estimate vs A4 target with tolerance=100', () => {
+      // +100 cents folds to 100; |100| <= 100
+      const result = evaluatePitchEstimate(
+        { frequency: AS4_FREQ },
+        { note: 'A', octave: 4 },
+        { pitchClassOnly: true, centsTolerance: 100 },
+      );
+
+      expect(result.withinTolerance).toBe(true);
+    });
+
+    it('uses folded cents for a flat estimate in pitch-class-only mode', () => {
+      // G#4 = -100 cents from A4; folded -100 is still -100; |-100| > 50
+      const result = evaluatePitchEstimate(
+        { frequency: GS4_FREQ },
+        { note: 'A', octave: 4 },
+        { pitchClassOnly: true },
+      );
+
+      expect(result.withinTolerance).toBe(false);
+    });
+
+    it('withinTolerance is true for small deviation in pitchClassOnly mode', () => {
+      // 20 cents sharp — |20| <= 50
+      const sharpBy20 = A4_FREQ * Math.pow(2, 20 / 1200);
+      const result = evaluatePitchEstimate(
+        { frequency: sharpBy20 },
+        { note: 'A', octave: 4 },
+        { pitchClassOnly: true },
+      );
+
+      expect(result.withinTolerance).toBe(true);
+    });
+  });
+
+  describe('clarity field (pass-through)', () => {
+    it('accepts and ignores clarity without error', () => {
+      const result = evaluatePitchEstimate(
+        { frequency: A4_FREQ, clarity: 0.95 },
+        { note: 'A', octave: 4 },
+      );
+
+      // clarity does not affect the result — just make sure it does not throw
+      expect(result.centsError).toBeCloseTo(0, 6);
+    });
+
+    it('accepts estimates with no clarity field', () => {
+      const result = evaluatePitchEstimate({ frequency: A4_FREQ }, { note: 'A', octave: 4 });
+
+      expect(result.withinTolerance).toBe(true);
+    });
+  });
+
+  describe('default options', () => {
+    it('defaults to 50-cent tolerance (boundary at exactly 50 cents)', () => {
+      // 50 cents sharp from A4 is exactly the semitone midpoint; it rounds to
+      // A#4, so registerMatches is false and withinTolerance is false.
+      // In pitchClassOnly mode, 50 cents folds to 50, and |50| <= 50 is true.
+      const sharpBy50 = A4_FREQ * Math.pow(2, 50 / 1200);
+
+      const registerResult = evaluatePitchEstimate(
+        { frequency: sharpBy50 },
+        { note: 'A', octave: 4 },
+      );
+      const pitchClassResult = evaluatePitchEstimate(
+        { frequency: sharpBy50 },
+        { note: 'A', octave: 4 },
+        { pitchClassOnly: true },
+      );
+
+      // nearestNote rounds to A#4 at the midpoint
+      expect(registerResult.nearestNote.note).toBe('A#');
+      expect(registerResult.withinTolerance).toBe(false);
+      // pitchClassOnly: folded 50 cents <= 50 is true
+      expect(pitchClassResult.withinTolerance).toBe(true);
+    });
+
+    it('defaults to register mode (not pitchClassOnly)', () => {
+      // A5 vs A4: likelyOctaveError but NOT withinTolerance in register mode
+      const result = evaluatePitchEstimate({ frequency: A5_FREQ }, { note: 'A', octave: 4 });
+
+      expect(result.likelyOctaveError).toBe(true);
+      expect(result.withinTolerance).toBe(false);
+    });
+  });
+
+  describe('target note spelled different ways', () => {
+    it('accepts note name string', () => {
+      // 'A' defaults to octave 4 — pitchClass matches for A4 target
+      const result = evaluatePitchEstimate({ frequency: A4_FREQ }, 'A');
+
+      expect(result.pitchClassMatches).toBe(true);
+    });
+
+    it('accepts object with note and octave', () => {
+      const result = evaluatePitchEstimate({ frequency: A4_FREQ }, { note: 'A', octave: 4 });
+
+      expect(result.registerMatches).toBe(true);
+    });
+
+    it('accepts Note instance as target', () => {
+      const target = Note.create({ note: 'A', octave: 4 });
+      const result = evaluatePitchEstimate({ frequency: A4_FREQ }, target);
+
+      expect(result.registerMatches).toBe(true);
+    });
+  });
+
+  describe('error propagation', () => {
+    it('throws RangeError for zero frequency', () => {
+      expect(() => evaluatePitchEstimate({ frequency: 0 }, { note: 'A', octave: 4 })).toThrow(
+        RangeError,
+      );
+    });
+
+    it('throws RangeError for negative frequency', () => {
+      expect(() => evaluatePitchEstimate({ frequency: -440 }, { note: 'A', octave: 4 })).toThrow(
+        RangeError,
+      );
+    });
+
+    it('throws RangeError for non-finite frequency', () => {
+      expect(() =>
+        evaluatePitchEstimate({ frequency: Number.POSITIVE_INFINITY }, { note: 'A', octave: 4 }),
+      ).toThrow(RangeError);
+    });
+
+    it('throws TypeError for invalid target note', () => {
+      expect(() =>
+        evaluatePitchEstimate({ frequency: A4_FREQ }, 'NotAValidNoteName' as never),
+      ).toThrow(TypeError);
+    });
+  });
+});

--- a/src/pitch/pitch-estimate.ts
+++ b/src/pitch/pitch-estimate.ts
@@ -1,0 +1,191 @@
+/**
+ * Pitch-estimate scoring helpers for Octavian.
+ *
+ * This module provides a pure scoring layer over an application-provided pitch
+ * estimate (e.g. from a tuner or pitch-detection algorithm). It does NOT
+ * perform pitch detection or open any microphone — the caller supplies the
+ * raw estimate.
+ *
+ * Import as `octavian/pitch` (subpath export — not part of the root barrel).
+ */
+
+import { centsBetween } from '../temperament.js';
+import { Note, noteToFrequency, type NoteLike } from '../note.js';
+import { STANDARD_TUNING, type Tuning } from '../tuning.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A raw pitch estimate provided by an external pitch-detection algorithm.
+ *
+ * Only `frequency` is required. `clarity` is an optional confidence value
+ * (0–1) that the caller may provide — it is not used by {@link evaluatePitchEstimate}
+ * but is preserved for callers who wish to gate on it.
+ */
+export type PitchEstimate = {
+  /** The estimated fundamental frequency in hertz. Must be positive and finite. */
+  readonly frequency: number;
+  /** Optional clarity / confidence value from the pitch detector (0–1). */
+  readonly clarity?: number;
+};
+
+/**
+ * The result of evaluating a {@link PitchEstimate} against a target note.
+ */
+export type PitchEvaluation = {
+  /**
+   * The equal-tempered note whose frequency is closest to the estimate.
+   * Resolved under the `tuning` option if provided.
+   */
+  readonly nearestNote: Note;
+  /**
+   * Signed cents from the target note's frequency to the estimate's frequency.
+   *
+   * Positive = estimate is sharp (above target).
+   * Negative = estimate is flat (below target).
+   * Range is unbounded — octave errors produce values around ±1200.
+   */
+  readonly centsError: number;
+  /**
+   * `true` when the nearest note shares the same pitch class (chromatic index)
+   * as the target note, regardless of octave.
+   */
+  readonly pitchClassMatches: boolean;
+  /**
+   * `true` when the nearest note is the same pitch class **and** the same
+   * octave as the target note.
+   */
+  readonly registerMatches: boolean;
+  /**
+   * `true` when the pitch class matches but the octave does not — the player
+   * is singing/playing the right note name in the wrong octave.
+   */
+  readonly likelyOctaveError: boolean;
+  /**
+   * `true` when the estimate is within the `centsTolerance` of the target.
+   *
+   * In default register mode: requires `registerMatches` to be `true` and
+   * `|centsError| <= centsTolerance`.
+   *
+   * In `pitchClassOnly` mode: the cents error is folded into the range
+   * [−600, 600] (ignoring octave displacement) and `|foldedCents| <= centsTolerance`.
+   */
+  readonly withinTolerance: boolean;
+};
+
+/**
+ * Options for {@link evaluatePitchEstimate}.
+ */
+export type EvaluatePitchEstimateOptions = {
+  /**
+   * The A4 reference frequency to use when resolving the target note's
+   * frequency and the nearest note.  Defaults to standard tuning (A4 = 440 Hz).
+   */
+  readonly tuning?: Tuning;
+  /**
+   * The maximum absolute cents deviation considered "in tune".
+   * Defaults to 50 cents (one quarter-tone).
+   */
+  readonly centsTolerance?: number;
+  /**
+   * When `true`, {@link PitchEvaluation.withinTolerance} ignores octave and
+   * only checks whether the estimate's cents error, folded into a single
+   * octave (±600 cents), is within `centsTolerance`.
+   *
+   * Useful for melodic exercises where the correct octave is optional.
+   */
+  readonly pitchClassOnly?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Helper: fold cents into (−600, 600] pitch-class space
+// ---------------------------------------------------------------------------
+
+/**
+ * Folds an unbounded cents value into (−600, 600] — a single octave centred
+ * on zero.  Used for pitch-class-only tolerance checking.
+ *
+ * @param cents The raw cents error (can be any finite number).
+ * @returns The folded value in (−600, 600].
+ */
+function foldCentsIntoPitchClass(cents: number): number {
+  // Normalise to [0, 1200) then shift to (−600, 600].
+  const mod = ((cents % 1200) + 1200) % 1200;
+
+  return mod > 600 ? mod - 1200 : mod;
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluates a raw pitch estimate against a target note, returning a detailed
+ * scoring breakdown.
+ *
+ * The `estimate.frequency` is compared to the equal-tempered frequency of
+ * `target` (under the provided `tuning`, defaulting to A4 = 440 Hz).
+ *
+ * Sign convention: `centsError` is positive when the estimate is **sharp**
+ * (above the target) and negative when **flat**.
+ *
+ * @param estimate The raw pitch estimate from a pitch-detection algorithm.
+ * @param target The target note the performer is supposed to be playing.
+ * @param options Optional scoring options (tuning, tolerance, pitchClassOnly).
+ * @returns A {@link PitchEvaluation} with the full scoring breakdown.
+ * @throws {RangeError} When `estimate.frequency` is not a positive finite
+ *   number (propagated from the underlying frequency utilities).
+ * @throws {TypeError} When `target` is not a valid note-like value.
+ */
+export function evaluatePitchEstimate(
+  estimate: PitchEstimate,
+  target: NoteLike,
+  options: EvaluatePitchEstimateOptions = {},
+): PitchEvaluation {
+  const { tuning = STANDARD_TUNING, centsTolerance = 50, pitchClassOnly = false } = options;
+
+  // Resolve target note and compute its frequency under the requested tuning.
+  const targetNote = Note.create(target);
+  const targetFrequency = Number(noteToFrequency(targetNote, tuning));
+
+  // Find the equal-tempered note nearest to the estimate under the same tuning.
+  const nearestNote = Note.nearestTo(estimate.frequency, tuning);
+
+  // centsError: positive = estimate is sharp (above target).
+  // centsBetween(a, b) = 1200 * log2(b/a), positive when b > a.
+  // So centsBetween(targetFrequency, estimateFrequency) is positive when
+  // estimate > target, matching the "positive = sharp" convention.
+  const centsError = centsBetween(targetFrequency, estimate.frequency);
+
+  // Pitch-class comparison (octave-invariant).
+  const pitchClassMatches = nearestNote.chromaticIndex === targetNote.chromaticIndex;
+
+  // Register match requires both pitch class and octave to agree.
+  const registerMatches =
+    pitchClassMatches && Number(nearestNote.octave) === Number(targetNote.octave);
+
+  // Octave error: right pitch class, wrong octave.
+  const likelyOctaveError = pitchClassMatches && !registerMatches;
+
+  // Tolerance check.
+  let withinTolerance: boolean;
+
+  if (pitchClassOnly) {
+    const folded = foldCentsIntoPitchClass(centsError);
+
+    withinTolerance = Math.abs(folded) <= centsTolerance;
+  } else {
+    withinTolerance = registerMatches && Math.abs(centsError) <= centsTolerance;
+  }
+
+  return {
+    nearestNote,
+    centsError,
+    pitchClassMatches,
+    registerMatches,
+    likelyOctaveError,
+    withinTolerance,
+  };
+}

--- a/src/pitch/pitch-estimate.ts
+++ b/src/pitch/pitch-estimate.ts
@@ -20,15 +20,11 @@ import { STANDARD_TUNING, type Tuning } from '../tuning.js';
 /**
  * A raw pitch estimate provided by an external pitch-detection algorithm.
  *
- * Only `frequency` is required. `clarity` is an optional confidence value
- * (0–1) that the caller may provide — it is not used by {@link evaluatePitchEstimate}
- * but is preserved for callers who wish to gate on it.
+ * Only `frequency` is required and consumed by {@link evaluatePitchEstimate}.
  */
 export type PitchEstimate = {
   /** The estimated fundamental frequency in hertz. Must be positive and finite. */
   readonly frequency: number;
-  /** Optional clarity / confidence value from the pitch detector (0–1). */
-  readonly clarity?: number;
 };
 
 /**
@@ -118,6 +114,28 @@ function foldCentsIntoPitchClass(cents: number): number {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: compute withinTolerance
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes whether a cents error is within the given tolerance, using either
+ * register mode (exact pitch + octave match required) or pitch-class-only mode
+ * (octave ignored, cents folded into one octave).
+ */
+function computeWithinTolerance(
+  centsError: number,
+  registerMatches: boolean,
+  centsTolerance: number,
+  pitchClassOnly: boolean,
+): boolean {
+  if (pitchClassOnly) {
+    return Math.abs(foldCentsIntoPitchClass(centsError)) <= centsTolerance;
+  }
+
+  return registerMatches && Math.abs(centsError) <= centsTolerance;
+}
+
+// ---------------------------------------------------------------------------
 // Main export
 // ---------------------------------------------------------------------------
 
@@ -137,6 +155,8 @@ function foldCentsIntoPitchClass(cents: number): number {
  * @returns A {@link PitchEvaluation} with the full scoring breakdown.
  * @throws {RangeError} When `estimate.frequency` is not a positive finite
  *   number (propagated from the underlying frequency utilities).
+ * @throws {RangeError} When `options.centsTolerance` is not a finite
+ *   non-negative number.
  * @throws {TypeError} When `target` is not a valid note-like value.
  */
 export function evaluatePitchEstimate(
@@ -145,6 +165,12 @@ export function evaluatePitchEstimate(
   options: EvaluatePitchEstimateOptions = {},
 ): PitchEvaluation {
   const { tuning = STANDARD_TUNING, centsTolerance = 50, pitchClassOnly = false } = options;
+
+  if (!Number.isFinite(centsTolerance) || centsTolerance < 0) {
+    throw new RangeError(
+      `Expected a finite non-negative centsTolerance, received ${centsTolerance}.`,
+    );
+  }
 
   // Resolve target note and compute its frequency under the requested tuning.
   const targetNote = Note.create(target);
@@ -170,15 +196,12 @@ export function evaluatePitchEstimate(
   const likelyOctaveError = pitchClassMatches && !registerMatches;
 
   // Tolerance check.
-  let withinTolerance: boolean;
-
-  if (pitchClassOnly) {
-    const folded = foldCentsIntoPitchClass(centsError);
-
-    withinTolerance = Math.abs(folded) <= centsTolerance;
-  } else {
-    withinTolerance = registerMatches && Math.abs(centsError) <= centsTolerance;
-  }
+  const withinTolerance = computeWithinTolerance(
+    centsError,
+    registerMatches,
+    centsTolerance,
+    pitchClassOnly,
+  );
 
   return {
     nearestNote,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,7 +6,15 @@ import { defineConfig } from 'tsdown';
 // and a runtime assertion in scripts/smoke-checks.mjs wired into
 // scripts/smoke-consumer-check.mjs so the tarball smoke test covers it.
 export default defineConfig({
-  entry: ['src/index.ts', 'src/sequences/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/sequences/index.ts',
+    'src/notation/index.ts',
+    'src/pitch/index.ts',
+    'src/midi/index.ts',
+    'src/midi-file/index.ts',
+    'src/performance-timing/index.ts',
+  ],
   outDir: 'dist/browser',
   format: 'esm',
   outExtensions: () => ({ js: '.js' }),


### PR DESCRIPTION
## Summary

Wave D, part 1: five new **pure** browser-safe subpath exports for `octavian`. Each builds on the existing theory primitives and the `octavian/sequences` foundation; none pollute the root export.

Closes #27, #33, #38, #37, and the message-layer portion of #31. (The `octavian/web-midi` browser adapter from #31 and `octavian/web-audio` from #32 land separately in PR-D2, since they need mocked-runtime tests and the import-time-no-browser-globals discipline.)

### The modules

- **`octavian/notation`** (#27) — renderer-neutral staff primitives: `staffPositionFor` (diatonic position + ledger-line count per clef), `accidentalForDisplay` (key-signature accidental suppression), `toNotationEvent`. Events are all-primitive plain objects, so `JSON.stringify` is the serialization.
- **`octavian/pitch`** (#33) — `evaluatePitchEstimate`: maps a detected frequency to the nearest `Note`, signed cents error, pitch-class vs register scoring, octave-error detection, configurable cents tolerance, alternate tuning.
- **`octavian/midi`** (#31, message layer) — `parseMidiMessage` (note-on/off/CC/program/pitch-bend; note-on-velocity-0 → note-off; full byte-range validation), `messageToNote`, an active-note state model with sustain-pedal capture, `sequenceToMidiMessages`.
- **`octavian/midi-file`** (#38) — `sequenceToMidiFile` / `parseMidiFile` / `midiFileToSequence`: Standard MIDI File bytes (MThd/MTrk, variable-length quantities, tempo + time-signature meta, end-of-track), deterministic output, round-trips tempo/meter/notes/velocities. Rejects malformed untrusted input.
- **`octavian/perf-timing`** (#37) — `quantizePerformance` (preserves humanized offsets), `comparePerformanceTiming` (early/late/on-time/missed/extra), `classifyTimingError`, `estimateTempoFromOnsets`, `measureSwingRatio`.

### Build wiring (the single hand-integrated step)

Five entries in `tsdown.config.ts`, five `"./<name>"` blocks in `package.json` exports (types-first; `./perf-timing` maps to the `performance-timing` dir), and five runtime assertions in `scripts/smoke-checks.mjs` exercised by the tarball smoke test. The root `src/index.ts` re-exports none of them.

## Verification

- `bun run validate` green: format, lint, typecheck, typecheck:test, **2552 tests**, build, `publint` + `attw` (all 7 exports 🟢 for node16-ESM and bundler), artifact validation across all 13 browser bundles (no Node/Bun globals), and the **tarball smoke test** — every new subpath imported through the exports map from a fresh consumer install.
- Non-parallel coverage: all 14 new module source files at **100% line + function**.

## Review committee

Built each module in an isolated worktree with an adversarial verifier, then ran the full committee (typescript-expert, simplicity-engineer, dx-engineer, testing-expert, Codex) before opening this PR. The committee caught a stack of real bugs that had passed both their own 100%-coverage tests and the per-module adversarial verifier:

- **Ledger-line off-by-one** (caught independently by testing-expert *and* Codex — the build agent's own tests had encoded the bug). Fixed `Math.ceil → Math.floor`; verified all eight staff positions against external musical ground truth.
- **`parseMidiMessage` had no byte-range validation** (`[0x90, 999, 500]` returned a typed note-on). Now validates every byte: `TypeError` for non-integers, `RangeError` out of 0..127 (status validated before the nibble mask).
- **SMF parser read past untrusted-input bounds** — track length vs file, meta length vs track end (including the VLQ read itself, now bounded at the track boundary), end-of-track length, channel-event truncation, and `>= 0x80` data bytes all rejected with `RangeError`.
- **`sequenceToMidiFile` options unvalidated** — `ticksPerQuarter` (1..32767), `channel` (0..15), and the SMF tempo range (including non-finite tempo reachable via a `Sequence` subclass) now throw.
- **Overlapping same-pitch MIDI notes collapsed** — active-note map re-keyed by `(channel, noteNumber)` with FIFO onset pairing; verified by hand.
- **The notation serializer was a do-nothing identity transform** referencing a nonexistent `deserializeNotationEvent` — removed; `JSON.stringify` is the serialization.
- Plus: `clarity` speculative field removed, `centsTolerance` validation, exact-count assertions, byte-advancement decode tests, and `parseMidiFile` now emits end-of-track so `MidiTrackEvent` is an honest union.

## Note (pre-existing, not introduced here)

`src/cadence.ts` is at 99.36% line coverage on clean `main` too — pre-existing, out of scope, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
