### PR TITLE
Add octavian/web-audio and octavian/web-midi browser adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,18 @@
       "import": "./dist/browser/performance-timing/index.js",
       "default": "./dist/browser/performance-timing/index.js"
     },
+    "./web-audio": {
+      "types": "./dist/web-audio/index.d.ts",
+      "browser": "./dist/browser/web-audio/index.js",
+      "import": "./dist/browser/web-audio/index.js",
+      "default": "./dist/browser/web-audio/index.js"
+    },
+    "./web-midi": {
+      "types": "./dist/web-midi/index.d.ts",
+      "browser": "./dist/browser/web-midi/index.js",
+      "import": "./dist/browser/web-midi/index.js",
+      "default": "./dist/browser/web-midi/index.js"
+    },
     "./package.json": "./package.json"
   },
   "types": "./dist/index.d.ts",

--- a/scripts/smoke-checks.mjs
+++ b/scripts/smoke-checks.mjs
@@ -116,3 +116,21 @@ export function assertPerfTimingSmokeChecks(perfTiming) {
     throw new Error('octavian/perf-timing: estimateTempoFromOnsets broken');
   }
 }
+
+// Browser-only ADAPTER subpath. EXISTENCE-ONLY: the renderer needs a real
+// AudioContext (absent under Bun), so we only assert the factory exists and
+// that bare-importing the module did not throw on a browser global.
+export function assertWebAudioSmokeChecks(webAudio) {
+  if (typeof webAudio.createWebAudioRenderer !== 'function') {
+    throw new Error('octavian/web-audio: createWebAudioRenderer missing');
+  }
+}
+
+// Browser-only ADAPTER subpath. EXISTENCE-ONLY: the controller needs a real
+// MIDIAccess (absent under Bun), so we only assert the factory exists and
+// that bare-importing the module did not throw on a browser global.
+export function assertWebMidiSmokeChecks(webMidi) {
+  if (typeof webMidi.createWebMidiInput !== 'function') {
+    throw new Error('octavian/web-midi: createWebMidiInput missing');
+  }
+}

--- a/scripts/smoke-consumer-check.mjs
+++ b/scripts/smoke-consumer-check.mjs
@@ -10,6 +10,8 @@ import {
   assertMidiSmokeChecks,
   assertMidiFileSmokeChecks,
   assertPerfTimingSmokeChecks,
+  assertWebAudioSmokeChecks,
+  assertWebMidiSmokeChecks,
 } from './_smoke-checks.mjs';
 
 const octavian = await import('octavian');
@@ -33,5 +35,13 @@ assertMidiFileSmokeChecks(midiFile, sequences);
 
 const perfTiming = await import('octavian/perf-timing');
 assertPerfTimingSmokeChecks(perfTiming);
+
+// Browser-only adapters: importing under Bun must not throw (proves no
+// import-time browser globals), and the factory must be present.
+const webAudio = await import('octavian/web-audio');
+assertWebAudioSmokeChecks(webAudio);
+
+const webMidi = await import('octavian/web-midi');
+assertWebMidiSmokeChecks(webMidi);
 
 process.stdout.write('tarball smoke test passed\n');

--- a/src/web-audio/index.ts
+++ b/src/web-audio/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Web Audio adapter for octavian.
+ *
+ * Import as `octavian/web-audio` (this is a subpath export, not part of the
+ * root barrel at `octavian`). The root `src/index.ts` MUST NOT re-export
+ * from this module.
+ *
+ * Provides {@link createWebAudioRenderer} — an oscillator-backed scheduler
+ * that accepts a caller-provided AudioContext and produces timed voices for
+ * notes, chords, and sequences.
+ *
+ * No browser globals are referenced at module scope. All runtime browser
+ * objects come from the caller.
+ *
+ * Import path: `octavian/web-audio`
+ */
+
+// Values
+export { createWebAudioRenderer } from './renderer.js';
+
+// Types
+export type {
+  AudioContextLike,
+  AudioNodeLike,
+  AudioParamLike,
+  GainNodeLike,
+  OscillatorNodeLike,
+  OfflineAudioContextLike,
+  Envelope,
+  ScheduleNoteOptions,
+  ScheduleChordOptions,
+  ScheduleSequenceOptions,
+  RenderOfflineOptions,
+  WebAudioRendererOptions,
+  WebAudioRenderer,
+} from './types.js';

--- a/src/web-audio/renderer-sequence.test.ts
+++ b/src/web-audio/renderer-sequence.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for the web-audio renderer's sequence-level scheduling
+ * (scheduleSequence and renderOffline).
+ *
+ * Split from renderer.test.ts to keep each file under the max-lines cap.
+ * Uses the same explicitly-typed fake AudioContext mocks (typed as *Like
+ * interfaces) to assert scheduling math without a real browser environment.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { Note } from '../note.js';
+import { Chord } from '../chord.js';
+import { Sequence, musicalTime } from '../sequences/sequence.js';
+import { createWebAudioRenderer } from './renderer.js';
+import type {
+  AudioContextLike,
+  AudioNodeLike,
+  AudioParamLike,
+  GainNodeLike,
+  OscillatorNodeLike,
+  OfflineAudioContextLike,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Fake builders (duplicated from renderer.test.ts — the repo splits large test
+// suites into sibling files that each carry their own setup, rather than
+// extracting a shared helper module).
+// ---------------------------------------------------------------------------
+
+type RecordedVoice = {
+  frequency: number;
+  startTime: number;
+  stopTime: number;
+  gainSchedule: Array<{ method: string; value: number; time: number }>;
+};
+
+function buildFakeParam(): AudioParamLike {
+  let val = 0;
+  return {
+    get value(): number {
+      return val;
+    },
+    set value(v: number) {
+      val = v;
+    },
+    setValueAtTime(v: number, _t: number): unknown {
+      val = v;
+      return undefined;
+    },
+    linearRampToValueAtTime(v: number, _t: number): unknown {
+      val = v;
+      return undefined;
+    },
+  };
+}
+
+function buildFakeAudioContext(currentTime = 0): {
+  ctx: AudioContextLike;
+  voices: RecordedVoice[];
+} {
+  const voices: RecordedVoice[] = [];
+
+  const destination: AudioNodeLike = {
+    connect(_node: AudioNodeLike): unknown {
+      return undefined;
+    },
+  };
+
+  const ctx: AudioContextLike = {
+    get currentTime(): number {
+      return currentTime;
+    },
+    createOscillator(): OscillatorNodeLike {
+      const freqParam = buildFakeParam();
+      const voice: RecordedVoice = { frequency: 0, startTime: 0, stopTime: 0, gainSchedule: [] };
+      voices.push(voice);
+      const osc: OscillatorNodeLike = {
+        type: 'sine',
+        frequency: {
+          get value(): number {
+            return freqParam.value;
+          },
+          set value(v: number) {
+            freqParam.value = v;
+          },
+          setValueAtTime(v: number, t: number): unknown {
+            voice.frequency = v;
+            return freqParam.setValueAtTime(v, t);
+          },
+          linearRampToValueAtTime(v: number, t: number): unknown {
+            return freqParam.linearRampToValueAtTime(v, t);
+          },
+        },
+        connect(_node: AudioNodeLike): unknown {
+          return undefined;
+        },
+        start(when: number): void {
+          voice.startTime = when;
+        },
+        stop(when: number): void {
+          voice.stopTime = when;
+        },
+      };
+      return osc;
+    },
+    createGain(): GainNodeLike {
+      const gain: GainNodeLike = {
+        gain: {
+          value: 1,
+          setValueAtTime(v: number, t: number): unknown {
+            voices[voices.length - 1]?.gainSchedule.push({ method: 'set', value: v, time: t });
+            return undefined;
+          },
+          linearRampToValueAtTime(v: number, t: number): unknown {
+            voices[voices.length - 1]?.gainSchedule.push({ method: 'ramp', value: v, time: t });
+            return undefined;
+          },
+        },
+        connect(_node: AudioNodeLike): unknown {
+          return undefined;
+        },
+      };
+      return gain;
+    },
+    destination,
+  };
+
+  return { ctx, voices };
+}
+
+function buildFakeOfflineContext(currentTime = 0): {
+  ctx: OfflineAudioContextLike;
+  voices: RecordedVoice[];
+  renderingPromise: Promise<unknown>;
+} {
+  const { ctx: baseCtx, voices } = buildFakeAudioContext(currentTime);
+  const renderingPromise = Promise.resolve({ sampleRate: 44100 });
+  const ctx: OfflineAudioContextLike = {
+    get currentTime(): number {
+      return baseCtx.currentTime;
+    },
+    createOscillator(): OscillatorNodeLike {
+      return baseCtx.createOscillator();
+    },
+    createGain(): GainNodeLike {
+      return baseCtx.createGain();
+    },
+    get destination(): AudioNodeLike {
+      return baseCtx.destination;
+    },
+    startRendering(): Promise<unknown> {
+      return renderingPromise;
+    },
+  };
+  return { ctx, voices, renderingPromise };
+}
+
+// ---------------------------------------------------------------------------
+// scheduleSequence
+// ---------------------------------------------------------------------------
+
+describe('scheduleSequence', () => {
+  it('schedules note and chord events; skips rests', () => {
+    const chord = Chord.create('G4', 'major');
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: Note.create('C4'),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+        },
+        { type: 'chord', chord, start: musicalTime(1, 4), duration: musicalTime(1, 4) },
+        { type: 'rest', start: musicalTime(1, 2), duration: musicalTime(1, 4) },
+      ],
+      { tempo: 60 },
+    );
+    const { ctx, voices } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: ctx }).scheduleSequence(seq);
+    expect(voices).toHaveLength(1 + chord.notes.length);
+  });
+
+  it('anchors at currentTime + startTime', () => {
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: Note.create('C4'),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+        },
+      ],
+      { tempo: 60 },
+    );
+    const { ctx, voices } = buildFakeAudioContext(5);
+    createWebAudioRenderer({ audioContext: ctx }).scheduleSequence(seq, { startTime: 2 });
+    const ev = seq.toAbsoluteSeconds()[0];
+    const voice = voices[0];
+    expect(ev).toBeDefined();
+    expect(voice).toBeDefined();
+    if (ev === undefined || voice === undefined) return;
+    expect(voice.startTime).toBeCloseTo(5 + 2 + ev.startSeconds, 5);
+    expect(voice.stopTime).toBeCloseTo(5 + 2 + ev.startSeconds + ev.durationSeconds, 5);
+  });
+
+  it('defaults startTime to 0 when absent', () => {
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: Note.create('C4'),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+        },
+      ],
+      { tempo: 60 },
+    );
+    const { ctx, voices } = buildFakeAudioContext(3);
+    createWebAudioRenderer({ audioContext: ctx }).scheduleSequence(seq);
+    const ev = seq.toAbsoluteSeconds()[0];
+    const voice = voices[0];
+    if (ev === undefined || voice === undefined) return;
+    expect(voice.startTime).toBeCloseTo(3 + ev.startSeconds, 5);
+  });
+
+  it('throws RangeError when note event has velocity=0', () => {
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: Note.create('C4'),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+          velocity: 0,
+        },
+      ],
+      { tempo: 60 },
+    );
+    const { ctx } = buildFakeAudioContext(0);
+    expect(() => createWebAudioRenderer({ audioContext: ctx }).scheduleSequence(seq)).toThrow(
+      RangeError,
+    );
+  });
+
+  it('throws RangeError when chord event has velocity=0', () => {
+    const seq = Sequence.create(
+      [
+        {
+          type: 'chord',
+          chord: Chord.create('C4', 'major'),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+          velocity: 0,
+        },
+      ],
+      { tempo: 60 },
+    );
+    const { ctx } = buildFakeAudioContext(0);
+    expect(() => createWebAudioRenderer({ audioContext: ctx }).scheduleSequence(seq)).toThrow(
+      RangeError,
+    );
+  });
+
+  it('explicit velocity=127 produces gain peak ≈ 1', () => {
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: Note.create('C4'),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+          velocity: 127,
+        },
+      ],
+      { tempo: 60 },
+    );
+    const { ctx, voices } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: ctx }).scheduleSequence(seq);
+    const peak = voices[0]?.gainSchedule.find((e) => e.method === 'ramp' && e.value > 0);
+    expect(peak).toBeDefined();
+    if (peak === undefined) return;
+    expect(peak.value).toBeCloseTo(1, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderOffline
+// ---------------------------------------------------------------------------
+
+describe('renderOffline', () => {
+  it('schedules on offline context and returns startRendering promise', async () => {
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: Note.create('C4'),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+        },
+      ],
+      { tempo: 60 },
+    );
+    const { ctx: offlineCtx, voices, renderingPromise } = buildFakeOfflineContext(0);
+    const { ctx: liveCtx } = buildFakeAudioContext(0);
+    const result = createWebAudioRenderer({ audioContext: liveCtx }).renderOffline(seq, {
+      offlineContext: offlineCtx,
+    });
+    expect(voices).toHaveLength(1);
+    expect(result).toBe(renderingPromise);
+    await expect(result).resolves.toBeDefined();
+  });
+
+  it('anchors at offlineContext.currentTime', () => {
+    const seq = Sequence.create(
+      [
+        {
+          type: 'note',
+          note: Note.create('C4'),
+          start: musicalTime(0, 1),
+          duration: musicalTime(1, 4),
+        },
+      ],
+      { tempo: 60 },
+    );
+    const { ctx: offlineCtx, voices } = buildFakeOfflineContext(0);
+    const { ctx: liveCtx } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: liveCtx }).renderOffline(seq, {
+      offlineContext: offlineCtx,
+    });
+    const ev = seq.toAbsoluteSeconds()[0];
+    const voice = voices[0];
+    if (ev === undefined || voice === undefined) return;
+    expect(voice.startTime).toBeCloseTo(ev.startSeconds, 5);
+  });
+
+  it('skips rests in offline rendering', () => {
+    const seq = Sequence.create(
+      [
+        { type: 'rest', start: musicalTime(0, 1), duration: musicalTime(1, 4) },
+        {
+          type: 'note',
+          note: Note.create('D4'),
+          start: musicalTime(1, 4),
+          duration: musicalTime(1, 4),
+        },
+      ],
+      { tempo: 60 },
+    );
+    const { ctx: offlineCtx, voices } = buildFakeOfflineContext(0);
+    const { ctx: liveCtx } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: liveCtx }).renderOffline(seq, {
+      offlineContext: offlineCtx,
+    });
+    expect(voices).toHaveLength(1);
+  });
+});

--- a/src/web-audio/renderer.test.ts
+++ b/src/web-audio/renderer.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Tests for the web-audio renderer.
+ *
+ * Uses explicitly-typed fake AudioContext mocks (typed as *Like interfaces)
+ * to assert scheduling math (start/stop times) and frequency values, without
+ * requiring a real browser environment.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { Note, noteToFrequency } from '../note.js';
+import { Chord } from '../chord.js';
+import { createFrequency } from '../branded-types.js';
+import { createWebAudioRenderer } from './renderer.js';
+import { createWebAudioRenderer as createFromBarrel } from './index.js';
+import type {
+  AudioContextLike,
+  AudioNodeLike,
+  AudioParamLike,
+  GainNodeLike,
+  OscillatorNodeLike,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Fake builders
+// ---------------------------------------------------------------------------
+
+type RecordedVoice = {
+  frequency: number;
+  startTime: number;
+  stopTime: number;
+  gainSchedule: Array<{ method: string; value: number; time: number }>;
+};
+
+// Extracted to outer scope to avoid recreating on every buildFakeAudioContext call.
+function buildFakeParam(): AudioParamLike {
+  let val = 0;
+  return {
+    get value(): number {
+      return val;
+    },
+    set value(v: number) {
+      val = v;
+    },
+    setValueAtTime(v: number, _t: number): unknown {
+      val = v;
+      return undefined;
+    },
+    linearRampToValueAtTime(v: number, _t: number): unknown {
+      val = v;
+      return undefined;
+    },
+  };
+}
+
+function buildFakeAudioContext(currentTime = 0): {
+  ctx: AudioContextLike;
+  voices: RecordedVoice[];
+} {
+  const voices: RecordedVoice[] = [];
+
+  const destination: AudioNodeLike = {
+    connect(_node: AudioNodeLike): unknown {
+      return undefined;
+    },
+  };
+
+  const ctx: AudioContextLike = {
+    get currentTime(): number {
+      return currentTime;
+    },
+    createOscillator(): OscillatorNodeLike {
+      const freqParam = buildFakeParam();
+      const voice: RecordedVoice = { frequency: 0, startTime: 0, stopTime: 0, gainSchedule: [] };
+      voices.push(voice);
+      const osc: OscillatorNodeLike = {
+        type: 'sine',
+        frequency: {
+          get value(): number {
+            return freqParam.value;
+          },
+          set value(v: number) {
+            freqParam.value = v;
+          },
+          setValueAtTime(v: number, t: number): unknown {
+            voice.frequency = v;
+            return freqParam.setValueAtTime(v, t);
+          },
+          linearRampToValueAtTime(v: number, t: number): unknown {
+            return freqParam.linearRampToValueAtTime(v, t);
+          },
+        },
+        connect(_node: AudioNodeLike): unknown {
+          return undefined;
+        },
+        start(when: number): void {
+          voice.startTime = when;
+        },
+        stop(when: number): void {
+          voice.stopTime = when;
+        },
+      };
+      return osc;
+    },
+    createGain(): GainNodeLike {
+      const gain: GainNodeLike = {
+        gain: {
+          value: 1,
+          setValueAtTime(v: number, t: number): unknown {
+            voices[voices.length - 1]?.gainSchedule.push({ method: 'set', value: v, time: t });
+            return undefined;
+          },
+          linearRampToValueAtTime(v: number, t: number): unknown {
+            voices[voices.length - 1]?.gainSchedule.push({ method: 'ramp', value: v, time: t });
+            return undefined;
+          },
+        },
+        connect(_node: AudioNodeLike): unknown {
+          return undefined;
+        },
+      };
+      return gain;
+    },
+    destination,
+  };
+
+  return { ctx, voices };
+}
+
+// ---------------------------------------------------------------------------
+// scheduleNote
+// ---------------------------------------------------------------------------
+
+describe('scheduleNote — basic scheduling', () => {
+  it('schedules start/stop times correctly', () => {
+    const { ctx, voices } = buildFakeAudioContext(10);
+    createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', {
+      startTime: 10,
+      duration: 2,
+    });
+    const voice = voices[0];
+    expect(voice).toBeDefined();
+    if (voice === undefined) return;
+    expect(voice.startTime).toBe(10);
+    expect(voice.stopTime).toBe(12);
+  });
+
+  it('sets the correct frequency — standard tuning', () => {
+    const { ctx, voices } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: ctx }).scheduleNote('A4', { startTime: 0, duration: 1 });
+    const voice = voices[0];
+    expect(voice).toBeDefined();
+    if (voice === undefined) return;
+    expect(voice.frequency).toBeCloseTo(440, 2);
+  });
+
+  it('uses tuning option — different A4 reference shifts frequency', () => {
+    const stdNote = Note.create('A4').frequency;
+    const altTuning = { reference: 'A4' as const, frequency: createFrequency(442) };
+    const { ctx, voices } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: ctx, tuning: altTuning }).scheduleNote('A4', {
+      startTime: 0,
+      duration: 1,
+    });
+    const voice = voices[0];
+    expect(voice).toBeDefined();
+    if (voice === undefined) return;
+    expect(voice.frequency).toBeCloseTo(442, 2);
+    expect(voice.frequency).not.toBeCloseTo(stdNote, 2);
+  });
+
+  it('envelope: gain ramps from 0 at start and back to 0 at end', () => {
+    const { ctx, voices } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', { startTime: 0, duration: 1 });
+    const voice = voices[0];
+    expect(voice).toBeDefined();
+    if (voice === undefined) return;
+    expect(voice.gainSchedule[0]).toMatchObject({ method: 'set', value: 0 });
+    expect(voice.gainSchedule[voice.gainSchedule.length - 1]).toMatchObject({
+      method: 'ramp',
+      value: 0,
+      time: 1,
+    });
+  });
+
+  it('absent velocity uses default — no throw, one voice created', () => {
+    const { ctx, voices } = buildFakeAudioContext(0);
+    expect(() =>
+      createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', {
+        startTime: 0,
+        duration: 1,
+      }),
+    ).not.toThrow();
+    expect(voices).toHaveLength(1);
+  });
+
+  it('high velocity produces larger gain peak than low velocity', () => {
+    const { ctx: ctxLow, voices: voicesLow } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: ctxLow }).scheduleNote('C4', {
+      startTime: 0,
+      duration: 1,
+      velocity: 1,
+    });
+    const { ctx: ctxHigh, voices: voicesHigh } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: ctxHigh }).scheduleNote('C4', {
+      startTime: 0,
+      duration: 1,
+      velocity: 127,
+    });
+    const lowPeak = voicesLow[0]?.gainSchedule.find((e) => e.method === 'ramp' && e.value > 0);
+    const highPeak = voicesHigh[0]?.gainSchedule.find((e) => e.method === 'ramp' && e.value > 0);
+    expect(lowPeak).toBeDefined();
+    expect(highPeak).toBeDefined();
+    if (lowPeak === undefined || highPeak === undefined) return;
+    expect(highPeak.value).toBeGreaterThan(lowPeak.value);
+  });
+
+  it('custom envelope overrides default attack', () => {
+    const { ctx, voices } = buildFakeAudioContext(0);
+    createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', {
+      startTime: 0,
+      duration: 2,
+      envelope: { attack: 0.5 },
+    });
+    const peakRamp = voices[0]?.gainSchedule.find((e) => e.method === 'ramp' && e.value > 0);
+    expect(peakRamp).toBeDefined();
+    if (peakRamp === undefined) return;
+    expect(peakRamp.time).toBeCloseTo(0.5, 5);
+  });
+
+  it('clamps attack to the note end when attack >= duration (degenerate envelope)', () => {
+    const { ctx, voices } = buildFakeAudioContext(0);
+    // attack (3s) exceeds duration (1s): the peak ramp must not be scheduled
+    // past the release ramp, or Web Audio's time-ordered automation breaks.
+    createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', {
+      startTime: 10,
+      duration: 1,
+      envelope: { attack: 3 },
+    });
+    const voice = voices[0];
+    expect(voice).toBeDefined();
+    if (voice === undefined) return;
+    const endTime = 11;
+    // Every gain automation time is at or before the note end — nothing past it.
+    for (const entry of voice.gainSchedule) {
+      expect(entry.time).toBeLessThanOrEqual(endTime);
+    }
+    // The peak ramp lands exactly on the end (clamped), not at start + attack (13).
+    const peakRamp = voice.gainSchedule.find((e) => e.method === 'ramp' && e.value > 0);
+    expect(peakRamp).toBeDefined();
+    if (peakRamp === undefined) return;
+    expect(peakRamp.time).toBeCloseTo(endTime, 5);
+  });
+});
+
+describe('scheduleNote — velocity-0 RangeError', () => {
+  it('throws RangeError for velocity=0', () => {
+    const { ctx } = buildFakeAudioContext(0);
+    expect(() =>
+      createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', {
+        startTime: 0,
+        duration: 1,
+        velocity: 0,
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('error message contains "received 0"', () => {
+    const { ctx } = buildFakeAudioContext(0);
+    expect(() =>
+      createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', {
+        startTime: 0,
+        duration: 1,
+        velocity: 0,
+      }),
+    ).toThrow('received 0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scheduleChord
+// ---------------------------------------------------------------------------
+
+describe('scheduleChord', () => {
+  it('schedules one voice per chord note', () => {
+    const { ctx, voices } = buildFakeAudioContext(0);
+    const chord = Chord.create('C4', 'major');
+    createWebAudioRenderer({ audioContext: ctx }).scheduleChord(chord, {
+      startTime: 5,
+      duration: 2,
+    });
+    expect(voices).toHaveLength(chord.notes.length);
+    for (const voice of voices) {
+      expect(voice.startTime).toBe(5);
+      expect(voice.stopTime).toBe(7);
+    }
+  });
+
+  it('frequencies match chord.notes', () => {
+    const { ctx, voices } = buildFakeAudioContext(0);
+    const chord = Chord.create('C4', 'major');
+    createWebAudioRenderer({ audioContext: ctx }).scheduleChord(chord, {
+      startTime: 0,
+      duration: 1,
+    });
+    for (let i = 0; i < voices.length; i++) {
+      const voice = voices[i];
+      const expected = chord.notes[i]?.frequency;
+      expect(voice).toBeDefined();
+      expect(expected).toBeDefined();
+      if (voice === undefined || expected === undefined) continue;
+      expect(voice.frequency).toBeCloseTo(expected, 2);
+    }
+  });
+
+  it('uses tuning option for chord note frequencies', () => {
+    const altTuning = { reference: 'A4' as const, frequency: createFrequency(442) };
+    const { ctx, voices } = buildFakeAudioContext(0);
+    const chord = Chord.create('A4', 'major');
+    createWebAudioRenderer({ audioContext: ctx, tuning: altTuning }).scheduleChord(chord, {
+      startTime: 0,
+      duration: 1,
+    });
+    for (let i = 0; i < voices.length; i++) {
+      const voice = voices[i];
+      const note = chord.notes[i];
+      if (voice === undefined || note === undefined) continue;
+      expect(voice.frequency).toBeCloseTo(noteToFrequency(note, altTuning), 2);
+    }
+  });
+
+  it('throws RangeError for velocity=0', () => {
+    const { ctx } = buildFakeAudioContext(0);
+    expect(() =>
+      createWebAudioRenderer({ audioContext: ctx }).scheduleChord(Chord.create('C4', 'major'), {
+        startTime: 0,
+        duration: 1,
+        velocity: 0,
+      }),
+    ).toThrow(RangeError);
+  });
+
+  it('absent velocity uses default — no throw', () => {
+    const { ctx, voices } = buildFakeAudioContext(0);
+    expect(() =>
+      createWebAudioRenderer({ audioContext: ctx }).scheduleChord(Chord.create('C4', 'major'), {
+        startTime: 0,
+        duration: 1,
+      }),
+    ).not.toThrow();
+    expect(voices.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shape check
+// ---------------------------------------------------------------------------
+
+describe('createWebAudioRenderer — shape', () => {
+  it('returns object with all four renderer methods', () => {
+    const { ctx } = buildFakeAudioContext(0);
+    const renderer = createWebAudioRenderer({ audioContext: ctx });
+    expect(typeof renderer.scheduleNote).toBe('function');
+    expect(typeof renderer.scheduleChord).toBe('function');
+    expect(typeof renderer.scheduleSequence).toBe('function');
+    expect(typeof renderer.renderOffline).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// barrel re-export
+// ---------------------------------------------------------------------------
+
+describe('index.ts barrel', () => {
+  it('re-exports createWebAudioRenderer', () => {
+    expect(typeof createFromBarrel).toBe('function');
+  });
+});

--- a/src/web-audio/renderer.test.ts
+++ b/src/web-audio/renderer.test.ts
@@ -252,27 +252,51 @@ describe('scheduleNote — basic scheduling', () => {
   });
 });
 
-describe('scheduleNote — velocity-0 RangeError', () => {
-  it('throws RangeError for velocity=0', () => {
+describe('scheduleNote — input validation', () => {
+  const render = (options: { startTime: number; duration: number; velocity?: number }) => {
     const { ctx } = buildFakeAudioContext(0);
-    expect(() =>
-      createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', {
-        startTime: 0,
-        duration: 1,
-        velocity: 0,
-      }),
-    ).toThrow(RangeError);
+    return () => createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', options);
+  };
+
+  it('throws RangeError for velocity=0 (note-off)', () => {
+    expect(render({ startTime: 0, duration: 1, velocity: 0 })).toThrow(RangeError);
+    expect(render({ startTime: 0, duration: 1, velocity: 0 })).toThrow('received 0');
   });
 
-  it('error message contains "received 0"', () => {
+  it('throws RangeError for velocity below 1', () => {
+    expect(render({ startTime: 0, duration: 1, velocity: -1 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for velocity above 127', () => {
+    expect(render({ startTime: 0, duration: 1, velocity: 128 })).toThrow(RangeError);
+  });
+
+  it('throws TypeError for a non-integer velocity', () => {
+    expect(render({ startTime: 0, duration: 1, velocity: 63.5 })).toThrow(TypeError);
+  });
+
+  it('throws RangeError for a non-positive duration', () => {
+    expect(render({ startTime: 0, duration: 0 })).toThrow(RangeError);
+    expect(render({ startTime: 0, duration: -1 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for a non-finite duration', () => {
+    expect(render({ startTime: 0, duration: Number.POSITIVE_INFINITY })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for a non-finite startTime', () => {
+    expect(render({ startTime: Number.NaN, duration: 1 })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for a negative envelope attack', () => {
     const { ctx } = buildFakeAudioContext(0);
     expect(() =>
       createWebAudioRenderer({ audioContext: ctx }).scheduleNote('C4', {
         startTime: 0,
         duration: 1,
-        velocity: 0,
+        envelope: { attack: -0.1 },
       }),
-    ).toThrow('received 0');
+    ).toThrow(RangeError);
   });
 });
 

--- a/src/web-audio/renderer.ts
+++ b/src/web-audio/renderer.ts
@@ -39,19 +39,55 @@ const DEFAULT_OSCILLATOR_TYPE = 'sine';
 /**
  * Resolves the effective velocity for a scheduled event.
  *
- * Returns `defaultVelocity` when `velocity` is absent. Throws when it is
- * present and equal to 0 (Web Audio has no "note-off" concept; velocity-0
- * is meaningless and indicates a caller error).
+ * Returns `defaultVelocity` when `velocity` is absent. A present velocity must
+ * be an integer in 1..127: `0` is note-off (meaningless for Web Audio, which
+ * has no note-off concept), and values outside the range produce out-of-bounds
+ * gain. Mirrors the validation in `octavian/midi` and `octavian/midi-file`.
  *
- * @throws {RangeError} When velocity is present and equals 0.
+ * @throws {TypeError} When velocity is present but not an integer.
+ * @throws {RangeError} When velocity is present and outside 1..127.
  */
 function resolveVelocity(velocity: number | undefined, defaultVelocity: number): number {
-  if (velocity !== undefined && velocity === 0) {
-    throw new RangeError(
-      `Note event velocity must be 1..127 for Web Audio scheduling (0 is interpreted as note-off), received 0.`,
+  if (velocity === undefined) {
+    return defaultVelocity;
+  }
+  if (!Number.isInteger(velocity)) {
+    throw new TypeError(
+      `Velocity must be an integer in 1..127 for Web Audio scheduling, received ${String(velocity)}.`,
     );
   }
-  return velocity ?? defaultVelocity;
+  if (velocity < 1 || velocity > 127) {
+    throw new RangeError(
+      `Velocity must be an integer in 1..127 for Web Audio scheduling (0 is interpreted as note-off), received ${velocity}.`,
+    );
+  }
+  return velocity;
+}
+
+/**
+ * Validates the timing inputs for a single scheduled voice.
+ *
+ * Web Audio's automation timeline requires finite, ordered times: a non-finite
+ * or non-positive `duration` (or non-finite `startTime` / negative `attack`)
+ * would schedule the release before the attack, or make the real API throw at
+ * scheduling time. Mirrors the finite-bounds checks in `octavian/midi-file`.
+ *
+ * @throws {RangeError} When startTime, duration, or attack are out of bounds.
+ */
+function validateVoiceTiming(startTime: number, duration: number, attack: number): void {
+  if (!Number.isFinite(startTime)) {
+    throw new RangeError(`startTime must be a finite number, received ${String(startTime)}.`);
+  }
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new RangeError(
+      `duration must be a finite number greater than 0, received ${String(duration)}.`,
+    );
+  }
+  if (!Number.isFinite(attack) || attack < 0) {
+    throw new RangeError(
+      `envelope attack must be a finite number >= 0, received ${String(attack)}.`,
+    );
+  }
 }
 
 /**
@@ -83,6 +119,8 @@ function scheduleVoice(
   gainPeak: number,
   envelope: Envelope,
 ): void {
+  validateVoiceTiming(startTime, duration, envelope.attack);
+
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();
 
@@ -121,7 +159,8 @@ function resolveFrequency(note: NoteLike, tuning: Tuning | undefined): number {
  *
  * Note and chord events are scheduled; rest events are skipped.
  *
- * @throws {RangeError} When a sequence event carries a present velocity of 0.
+ * @throws {TypeError} When an event velocity is present but not an integer.
+ * @throws {RangeError} When an event velocity is outside 1..127 or its timing is out of bounds.
  */
 function scheduleEvents(
   ctx: AudioContextLike,

--- a/src/web-audio/renderer.ts
+++ b/src/web-audio/renderer.ts
@@ -1,0 +1,243 @@
+/**
+ * Web Audio oscillator-backed renderer implementation.
+ *
+ * All scheduling goes through `scheduleVoice`, which creates an
+ * OscillatorNode + GainNode on the caller-provided context. No browser
+ * globals are referenced at module scope — everything comes from the caller.
+ */
+
+import { Note, noteToFrequency } from '../note.js';
+import type { NoteLike } from '../note.js';
+import type { Chord } from '../chord.js';
+import type { Tuning } from '../tuning.js';
+import type { Sequence } from '../sequences/sequence.js';
+import type { TimedMusicEvent } from '../sequences/types.js';
+import type {
+  AudioContextLike,
+  AudioNodeLike,
+  Envelope,
+  RenderOfflineOptions,
+  ScheduleChordOptions,
+  ScheduleNoteOptions,
+  ScheduleSequenceOptions,
+  WebAudioRenderer,
+  WebAudioRendererOptions,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Module-level constants — no browser globals
+// ---------------------------------------------------------------------------
+
+const DEFAULT_VELOCITY = 64;
+const DEFAULT_ATTACK = 0.01;
+const DEFAULT_OSCILLATOR_TYPE = 'sine';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the effective velocity for a scheduled event.
+ *
+ * Returns `defaultVelocity` when `velocity` is absent. Throws when it is
+ * present and equal to 0 (Web Audio has no "note-off" concept; velocity-0
+ * is meaningless and indicates a caller error).
+ *
+ * @throws {RangeError} When velocity is present and equals 0.
+ */
+function resolveVelocity(velocity: number | undefined, defaultVelocity: number): number {
+  if (velocity !== undefined && velocity === 0) {
+    throw new RangeError(
+      `Note event velocity must be 1..127 for Web Audio scheduling (0 is interpreted as note-off), received 0.`,
+    );
+  }
+  return velocity ?? defaultVelocity;
+}
+
+/**
+ * Converts a MIDI velocity (1..127) to a normalised gain value (0..1).
+ *
+ * Uses a simple linear mapping: `velocity / 127`.
+ */
+function velocityToGain(velocity: number): number {
+  return velocity / 127;
+}
+
+/**
+ * Schedules a single oscillator+gain voice on `ctx`.
+ *
+ * Wires: osc → gain → ctx.destination. Applies a simple ADSR-ish ramp:
+ * gain starts at 0, ramps linearly to `gainPeak` over `attack` seconds,
+ * then ramps back to 0 at `startTime + duration`.
+ *
+ * The attack is clamped to the note's end so that a degenerate
+ * `attack >= duration` cannot schedule the peak ramp after the release ramp
+ * (Web Audio processes automations in time order, which would otherwise
+ * produce an unpredictable, never-fading gain).
+ */
+function scheduleVoice(
+  ctx: AudioContextLike,
+  frequency: number,
+  startTime: number,
+  duration: number,
+  gainPeak: number,
+  envelope: Envelope,
+): void {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  osc.type = DEFAULT_OSCILLATOR_TYPE;
+  osc.frequency.setValueAtTime(frequency, startTime);
+
+  const endTime = startTime + duration;
+  const attackEnd = Math.min(startTime + envelope.attack, endTime);
+
+  gain.gain.setValueAtTime(0, startTime);
+  gain.gain.linearRampToValueAtTime(gainPeak, attackEnd);
+  gain.gain.linearRampToValueAtTime(0, endTime);
+
+  // Route: osc → gain → destination.
+  // GainNodeLike extends AudioNodeLike so the cast is via the shared base type.
+  const gainAsNode: AudioNodeLike = gain;
+  osc.connect(gainAsNode);
+  gain.connect(ctx.destination);
+
+  osc.start(startTime);
+  osc.stop(endTime);
+}
+
+/**
+ * Returns the frequency for `note`, using `tuning` when provided.
+ */
+function resolveFrequency(note: NoteLike, tuning: Tuning | undefined): number {
+  if (tuning !== undefined) {
+    return noteToFrequency(note, tuning);
+  }
+  return Note.create(note).frequency;
+}
+
+/**
+ * Schedules all timed music events onto `ctx`, anchored at `anchorSeconds`.
+ *
+ * Note and chord events are scheduled; rest events are skipped.
+ *
+ * @throws {RangeError} When a sequence event carries a present velocity of 0.
+ */
+function scheduleEvents(
+  ctx: AudioContextLike,
+  events: readonly TimedMusicEvent[],
+  anchorSeconds: number,
+  defaultVelocity: number,
+  defaultEnvelope: Envelope,
+  tuning: Tuning | undefined,
+): void {
+  for (const ev of events) {
+    if (ev.type === 'rest') {
+      continue;
+    }
+
+    const velocity = resolveVelocity(ev.velocity, defaultVelocity);
+    const gainPeak = velocityToGain(velocity);
+    const startTime = anchorSeconds + ev.startSeconds;
+    const duration = ev.durationSeconds;
+
+    if (ev.type === 'note') {
+      const frequency = resolveFrequency(ev.note, tuning);
+      scheduleVoice(ctx, frequency, startTime, duration, gainPeak, defaultEnvelope);
+    } else {
+      // ev.type === 'chord'
+      for (const note of ev.chord.notes) {
+        const frequency = resolveFrequency(note, tuning);
+        scheduleVoice(ctx, frequency, startTime, duration, gainPeak, defaultEnvelope);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// createWebAudioRenderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a Web Audio renderer backed by oscillator+gain voices.
+ *
+ * All scheduling is performed on the caller-provided `audioContext`. No
+ * browser globals are accessed at module import time.
+ *
+ * @example
+ * ```ts
+ * const ctx = new AudioContext();
+ * const renderer = createWebAudioRenderer({ audioContext: ctx });
+ * renderer.scheduleNote('C4', { startTime: ctx.currentTime, duration: 1 });
+ * ```
+ */
+export function createWebAudioRenderer(options: WebAudioRendererOptions): WebAudioRenderer {
+  const { audioContext, tuning } = options;
+  const defaultEnvelope: Envelope = { attack: DEFAULT_ATTACK };
+
+  const renderer: WebAudioRenderer = {
+    scheduleNote(note: NoteLike, noteOptions: ScheduleNoteOptions): void {
+      const velocity = resolveVelocity(noteOptions.velocity, DEFAULT_VELOCITY);
+      const gainPeak = velocityToGain(velocity);
+      const envelope = noteOptions.envelope ?? defaultEnvelope;
+      const frequency = resolveFrequency(note, tuning);
+      scheduleVoice(
+        audioContext,
+        frequency,
+        noteOptions.startTime,
+        noteOptions.duration,
+        gainPeak,
+        envelope,
+      );
+    },
+
+    scheduleChord(chord: Chord, chordOptions: ScheduleChordOptions): void {
+      const velocity = resolveVelocity(chordOptions.velocity, DEFAULT_VELOCITY);
+      const gainPeak = velocityToGain(velocity);
+      for (const note of chord.notes) {
+        const frequency = resolveFrequency(note, tuning);
+        scheduleVoice(
+          audioContext,
+          frequency,
+          chordOptions.startTime,
+          chordOptions.duration,
+          gainPeak,
+          defaultEnvelope,
+        );
+      }
+    },
+
+    scheduleSequence(sequence: Sequence, seqOptions?: ScheduleSequenceOptions): void {
+      const startOffset = seqOptions?.startTime ?? 0;
+      const anchorSeconds = audioContext.currentTime + startOffset;
+      const events = sequence.toAbsoluteSeconds();
+      scheduleEvents(
+        audioContext,
+        events,
+        anchorSeconds,
+        DEFAULT_VELOCITY,
+        defaultEnvelope,
+        tuning,
+      );
+    },
+
+    renderOffline(sequence: Sequence, offlineOptions: RenderOfflineOptions): Promise<unknown> {
+      const { offlineContext } = offlineOptions;
+      const anchorSeconds = offlineContext.currentTime;
+      const events = sequence.toAbsoluteSeconds();
+      // OfflineAudioContextLike extends AudioContextLike structurally.
+      const offlineAsCtx: AudioContextLike = offlineContext;
+      scheduleEvents(
+        offlineAsCtx,
+        events,
+        anchorSeconds,
+        DEFAULT_VELOCITY,
+        defaultEnvelope,
+        tuning,
+      );
+      return offlineContext.startRendering();
+    },
+  };
+
+  return renderer;
+}

--- a/src/web-audio/types.ts
+++ b/src/web-audio/types.ts
@@ -1,0 +1,281 @@
+/**
+ * Structural *Like interfaces for Web Audio API objects.
+ *
+ * These are minimal structural interfaces declaring only the members actually
+ * called by the web-audio renderer. They exist because tsconfig `lib` is
+ * `["ESNext"]` — there is no DOM lib in this repo, so `AudioContext`,
+ * `OscillatorNode`, `GainNode` etc. are not known global type names.
+ *
+ * Signatures match the MDN Web Audio API specification.
+ */
+
+import type { Tuning } from '../tuning.js';
+import type { NoteLike } from '../note.js';
+import type { Chord } from '../chord.js';
+import type { Sequence } from '../sequences/sequence.js';
+
+// ---------------------------------------------------------------------------
+// AudioNodeLike
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural interface for an AudioNode — supports `connect` only.
+ */
+export type AudioNodeLike = {
+  /** Connects this node's output to the input of another node. */
+  connect(node: AudioNodeLike): unknown;
+};
+
+// ---------------------------------------------------------------------------
+// AudioParamLike
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural interface for an AudioParam.
+ *
+ * Supports scheduling value changes via `setValueAtTime` and
+ * `linearRampToValueAtTime`, plus direct `value` reads.
+ */
+export type AudioParamLike = {
+  /** Current value of the audio parameter. */
+  value: number;
+  /**
+   * Schedules a parameter value change at a precise time.
+   *
+   * @param value - The value to set.
+   * @param startTime - The time (in seconds) at which to set the value.
+   */
+  setValueAtTime(value: number, startTime: number): unknown;
+  /**
+   * Schedules a linear ramp to reach a target value by a given time.
+   *
+   * @param value - The target value.
+   * @param endTime - The time (in seconds) to reach the target value.
+   */
+  linearRampToValueAtTime(value: number, endTime: number): unknown;
+};
+
+// ---------------------------------------------------------------------------
+// OscillatorNodeLike
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural interface for an OscillatorNode.
+ *
+ * Covers frequency control, type selection, routing, and start/stop
+ * scheduling.
+ */
+export type OscillatorNodeLike = AudioNodeLike & {
+  /** Controls the frequency of the oscillator in Hz. */
+  frequency: AudioParamLike;
+  /** Waveform type (e.g. `'sine'`, `'square'`, `'sawtooth'`, `'triangle'`). */
+  type: string;
+  /**
+   * Schedules the oscillator to start at the given time.
+   *
+   * @param when - Context time (in seconds) to begin.
+   */
+  start(when: number): void;
+  /**
+   * Schedules the oscillator to stop at the given time.
+   *
+   * @param when - Context time (in seconds) to stop.
+   */
+  stop(when: number): void;
+};
+
+// ---------------------------------------------------------------------------
+// GainNodeLike
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural interface for a GainNode.
+ *
+ * Covers gain control and routing.
+ */
+export type GainNodeLike = AudioNodeLike & {
+  /** Controls the gain (amplitude) of the signal. */
+  gain: AudioParamLike;
+};
+
+// ---------------------------------------------------------------------------
+// AudioContextLike
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural interface for an AudioContext (online or offline).
+ *
+ * Covers only the factory methods and destination used by the renderer.
+ */
+export type AudioContextLike = {
+  /** Current playback position of the context, in seconds. */
+  readonly currentTime: number;
+  /** Creates a new OscillatorNode. */
+  createOscillator(): OscillatorNodeLike;
+  /** Creates a new GainNode. */
+  createGain(): GainNodeLike;
+  /** The final destination node of the audio graph. */
+  readonly destination: AudioNodeLike;
+};
+
+// ---------------------------------------------------------------------------
+// OfflineAudioContextLike
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal structural interface for an OfflineAudioContext.
+ *
+ * Extends {@link AudioContextLike} with `startRendering`, which begins
+ * offline rendering and resolves with the rendered audio buffer.
+ */
+export type OfflineAudioContextLike = AudioContextLike & {
+  /**
+   * Begins rendering and returns a Promise that resolves with the rendered
+   * audio buffer.
+   */
+  startRendering(): Promise<unknown>;
+};
+
+// ---------------------------------------------------------------------------
+// Envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * A simple ADSR-ish gain envelope for a scheduled voice.
+ *
+ * All times are relative offsets from the voice's `startTime`, in seconds.
+ * The envelope ramps gain from 0 → peak over `attack`, holds at peak, then
+ * ramps back to 0 at `startTime + duration`.
+ */
+export type Envelope = {
+  /**
+   * Time (in seconds) to ramp from silence to full gain after the voice
+   * starts. Must be ≥ 0. Defaults to `0.01`.
+   */
+  readonly attack: number;
+};
+
+// ---------------------------------------------------------------------------
+// ScheduleNoteOptions
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link WebAudioRenderer.scheduleNote}.
+ */
+export type ScheduleNoteOptions = {
+  /** Absolute audio-context time (seconds) at which to start the note. */
+  readonly startTime: number;
+  /** Duration of the note in seconds. */
+  readonly duration: number;
+  /** Optional gain envelope overriding the renderer default. */
+  readonly envelope?: Envelope;
+  /**
+   * MIDI velocity (1..127). Absent → use the renderer default velocity.
+   * A present value of 0 throws RangeError (0 = note-off).
+   */
+  readonly velocity?: number;
+};
+
+// ---------------------------------------------------------------------------
+// ScheduleChordOptions
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link WebAudioRenderer.scheduleChord}.
+ */
+export type ScheduleChordOptions = {
+  /** Absolute audio-context time (seconds) at which to start the chord. */
+  readonly startTime: number;
+  /** Duration of the chord in seconds. */
+  readonly duration: number;
+  /**
+   * MIDI velocity (1..127). Absent → use the renderer default velocity.
+   * A present value of 0 throws RangeError (0 = note-off).
+   */
+  readonly velocity?: number;
+};
+
+// ---------------------------------------------------------------------------
+// ScheduleSequenceOptions
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link WebAudioRenderer.scheduleSequence}.
+ */
+export type ScheduleSequenceOptions = {
+  /**
+   * Additional offset (in seconds) added to `audioContext.currentTime` before
+   * placing the first event. Defaults to `0`.
+   */
+  readonly startTime?: number;
+};
+
+// ---------------------------------------------------------------------------
+// RenderOfflineOptions
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link WebAudioRenderer.renderOffline}.
+ */
+export type RenderOfflineOptions = {
+  /**
+   * Caller-constructed offline audio context. The renderer wires the
+   * oscillator/gain graph onto this context and calls `startRendering()`.
+   */
+  readonly offlineContext: OfflineAudioContextLike;
+};
+
+// ---------------------------------------------------------------------------
+// WebAudioRendererOptions
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link createWebAudioRenderer}.
+ */
+export type WebAudioRendererOptions = {
+  /** The live AudioContext to schedule voices on. */
+  readonly audioContext: AudioContextLike;
+  /**
+   * Optional tuning reference. When provided, `noteToFrequency(note, tuning)`
+   * is used instead of `note.frequency`. Defaults to A4 = 440 Hz.
+   */
+  readonly tuning?: Tuning;
+};
+
+// ---------------------------------------------------------------------------
+// WebAudioRenderer
+// ---------------------------------------------------------------------------
+
+/**
+ * The renderer object returned by {@link createWebAudioRenderer}.
+ */
+export type WebAudioRenderer = {
+  /**
+   * Schedules a single oscillator+gain voice for one note.
+   *
+   * @throws {RangeError} When a present velocity is 0.
+   */
+  scheduleNote(note: NoteLike, options: ScheduleNoteOptions): void;
+
+  /**
+   * Schedules one oscillator+gain voice per note in the chord.
+   *
+   * @throws {RangeError} When a present velocity is 0.
+   */
+  scheduleChord(chord: Chord, options: ScheduleChordOptions): void;
+
+  /**
+   * Iterates `sequence.toAbsoluteSeconds()` and schedules every note/chord
+   * event anchored at `audioContext.currentTime + (startTime ?? 0)`.
+   * Rest events are skipped.
+   *
+   * @throws {RangeError} When a sequence event has a present velocity of 0.
+   */
+  scheduleSequence(sequence: Sequence, options?: ScheduleSequenceOptions): void;
+
+  /**
+   * Schedules all sequence events onto `offlineContext` (anchored at
+   * `offlineContext.currentTime`) and returns `offlineContext.startRendering()`.
+   */
+  renderOffline(sequence: Sequence, options: RenderOfflineOptions): Promise<unknown>;
+};

--- a/src/web-audio/types.ts
+++ b/src/web-audio/types.ts
@@ -125,13 +125,19 @@ export type AudioContextLike = {
 /**
  * Minimal structural interface for an OfflineAudioContext.
  *
- * Extends {@link AudioContextLike} with `startRendering`, which begins
- * offline rendering and resolves with the rendered audio buffer.
+ * Extends {@link AudioContextLike} with `startRendering`, which begins offline
+ * rendering and resolves with the platform's rendered audio buffer.
  */
 export type OfflineAudioContextLike = AudioContextLike & {
   /**
-   * Begins rendering and returns a Promise that resolves with the rendered
-   * audio buffer.
+   * Begins rendering and returns a Promise that resolves with the platform's
+   * rendered audio buffer.
+   *
+   * Typed as `unknown` on purpose: this package has no DOM lib, so it cannot
+   * reference the real `AudioBuffer` type, and the renderer only passes the
+   * result through — it never reads it. A caller (which, by virtue of owning an
+   * `OfflineAudioContext`, is already in a DOM-typed context) can cast the
+   * resolved value to `AudioBuffer` for full fidelity.
    */
   startRendering(): Promise<unknown>;
 };
@@ -276,6 +282,10 @@ export type WebAudioRenderer = {
   /**
    * Schedules all sequence events onto `offlineContext` (anchored at
    * `offlineContext.currentTime`) and returns `offlineContext.startRendering()`.
+   *
+   * Resolves with the platform's rendered audio buffer, typed `unknown` (this
+   * package has no DOM lib). Cast the resolved value to `AudioBuffer` in a DOM
+   * context. See {@link OfflineAudioContextLike.startRendering}.
    */
   renderOffline(sequence: Sequence, options: RenderOfflineOptions): Promise<unknown>;
 };

--- a/src/web-midi/index.ts
+++ b/src/web-midi/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Browser Web MIDI adapter for octavian.
+ *
+ * Import as `octavian/web-midi` (this is a subpath export, not part of the
+ * root barrel at `octavian`). The root `src/index.ts` MUST NOT re-export
+ * from this module.
+ *
+ * Provides:
+ * - {@link createWebMidiInput} — subscribe to a caller-owned MIDIAccess object,
+ *   receive parsed MIDI messages, note transitions, and chord changes, and
+ *   query the current active-note state.
+ *
+ * Import path: `octavian/web-midi`
+ *
+ * The module top level does NOT reference any browser global. All runtime Web
+ * MIDI objects are provided by the caller via `options.midiAccess`. The module
+ * is safe to import in non-browser environments (Bun, Node) without throwing.
+ */
+
+// Values first, then types.
+
+export { createWebMidiInput } from './web-midi-input.js';
+
+export type {
+  MIDIAccessLike,
+  MIDIInputLike,
+  MIDIInputsLike,
+  MIDIMessageEventLike,
+  OnMessageCallback,
+  OnNoteCallback,
+  OnChordCallback,
+  WebMidiInputOptions,
+  WebMidiInputController,
+} from './types.js';

--- a/src/web-midi/types.ts
+++ b/src/web-midi/types.ts
@@ -32,12 +32,13 @@ export type MIDIInputLike = {
 /**
  * A Web MIDI message event.
  *
- * `data` may be null on some browser implementations — the adapter guards
- * against this by skipping any event whose data is null or empty.
+ * Per the Web MIDI spec, `data` is a non-null `Uint8Array`. The adapter still
+ * skips any event whose data is empty or whose first byte is not a channel-voice
+ * status byte.
  */
 export type MIDIMessageEventLike = {
-  /** Raw MIDI bytes. May be null; guard before use. */
-  readonly data: Uint8Array | null;
+  /** Raw MIDI bytes (the message's status + data bytes). */
+  readonly data: Uint8Array;
 };
 
 /**

--- a/src/web-midi/types.ts
+++ b/src/web-midi/types.ts
@@ -1,0 +1,158 @@
+/**
+ * Structural interfaces for Web MIDI API objects used by {@link createWebMidiInput}.
+ *
+ * tsconfig `lib` is `["ESNext"]` — real `MIDIAccess`, `MIDIInput`, and
+ * `MIDIMessageEvent` are not known type names here. These minimal interfaces
+ * describe exactly the members this module calls. Any Web MIDI object that
+ * satisfies the shapes can be passed in.
+ *
+ * Signatures are MDN-accurate. Only members actually used by this module are
+ * declared — every extra member would be unverified surface.
+ */
+
+import type { Note } from '../note.js';
+import type { Chord } from '../chord.js';
+import type { MidiMessage } from '../midi/types.js';
+
+// ---------------------------------------------------------------------------
+// Web MIDI structural interfaces
+// ---------------------------------------------------------------------------
+
+/**
+ * A single Web MIDI input port.
+ *
+ * The adapter binds and unbinds by assigning the `onmidimessage` property
+ * directly (MDN's primary surface; equivalent to addEventListener('midimessage')).
+ */
+export type MIDIInputLike = {
+  /** Handler invoked for each incoming MIDI message event, or null when unbound. */
+  onmidimessage: ((event: MIDIMessageEventLike) => void) | null;
+};
+
+/**
+ * A Web MIDI message event.
+ *
+ * `data` may be null on some browser implementations — the adapter guards
+ * against this by skipping any event whose data is null or empty.
+ */
+export type MIDIMessageEventLike = {
+  /** Raw MIDI bytes. May be null; guard before use. */
+  readonly data: Uint8Array | null;
+};
+
+/**
+ * A read-only Map-like collection of MIDI inputs keyed by port id.
+ *
+ * MDN: `MIDIInputMap` is a read-only Map<string, MIDIInput>. The adapter only
+ * iterates `values()` — no key access is needed.
+ */
+export type MIDIInputsLike = {
+  /** Returns an iterator over all current MIDI inputs. */
+  values(): IterableIterator<MIDIInputLike>;
+};
+
+/**
+ * A Web MIDI access object returned by `navigator.requestMIDIAccess()`.
+ *
+ * The caller owns permissions and construction; the adapter only reads
+ * `midiAccess.inputs` to enumerate and bind ports.
+ */
+export type MIDIAccessLike = {
+  /** The available MIDI input ports. */
+  readonly inputs: MIDIInputsLike;
+};
+
+// ---------------------------------------------------------------------------
+// Callback types
+// ---------------------------------------------------------------------------
+
+/**
+ * Callback invoked for every successfully-parsed MIDI message.
+ */
+export type OnMessageCallback = (message: MidiMessage) => void;
+
+/**
+ * Callback invoked when a note-on or note-off event is received.
+ *
+ * Both the resolved {@link Note} and the originating {@link MidiMessage} are
+ * provided so the consumer can distinguish press from release via `message.type`.
+ */
+export type OnNoteCallback = (note: Note, message: MidiMessage) => void;
+
+/**
+ * Callback invoked when the detected chord changes.
+ *
+ * Fires when the chord transitions: null → chord, chord → different chord, or
+ * chord → null (all notes released). Does NOT fire when the chord is unchanged.
+ * Receives the new chord, or null when no chord is detectable.
+ */
+export type OnChordCallback = (chord: Chord | null) => void;
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link createWebMidiInput}.
+ */
+export type WebMidiInputOptions = {
+  /** The Web MIDI access object whose inputs will be subscribed to. */
+  readonly midiAccess: MIDIAccessLike;
+
+  /**
+   * Invoked for every successfully-parsed MIDI message arriving on any input.
+   * Optional.
+   */
+  readonly onMessage?: OnMessageCallback;
+
+  /**
+   * Invoked on note-on and note-off transitions with the resolved note and
+   * the originating message. Optional.
+   */
+  readonly onNote?: OnNoteCallback;
+
+  /**
+   * Invoked when the detected chord changes (including to null). Optional.
+   */
+  readonly onChord?: OnChordCallback;
+
+  /**
+   * Accidental preference for spelling note names. Defaults to `'sharps'`.
+   */
+  readonly accidentalPreference?: 'sharps' | 'flats';
+};
+
+// ---------------------------------------------------------------------------
+// Controller return type
+// ---------------------------------------------------------------------------
+
+/**
+ * The controller returned by {@link createWebMidiInput}.
+ *
+ * Exposes queryable state and teardown. `stop` and `dispose` are the same
+ * function — use whichever fits your coding style.
+ */
+export type WebMidiInputController = {
+  /**
+   * Returns the currently-sounding notes (held + sustained).
+   * Reads live state; call at any time.
+   */
+  getNotes(): readonly Note[];
+
+  /**
+   * Returns the currently-detectable chord, or null when fewer than 2 distinct
+   * pitch classes are sounding or the pitch set does not match a known chord.
+   */
+  getChord(): Chord | null;
+
+  /**
+   * Detaches the MIDI message handler from every input bound at creation time.
+   * Safe to call more than once. After stop(), further messages are ignored.
+   */
+  stop(): void;
+
+  /**
+   * Alias for {@link stop}. Detaches handlers from all bound inputs.
+   */
+  dispose(): void;
+};

--- a/src/web-midi/web-midi-input.test.ts
+++ b/src/web-midi/web-midi-input.test.ts
@@ -23,11 +23,11 @@ import type { Chord } from '../chord.js';
 // ---------------------------------------------------------------------------
 
 function makeFakeInput(): MIDIInputLike & {
-  fire(data: Uint8Array | null): void;
+  fire(data: Uint8Array): void;
 } {
   const fake = {
     onmidimessage: null as ((event: MIDIMessageEventLike) => void) | null,
-    fire(data: Uint8Array | null): void {
+    fire(data: Uint8Array): void {
       const event: MIDIMessageEventLike = { data };
       if (fake.onmidimessage !== null) {
         fake.onmidimessage(event);
@@ -73,7 +73,9 @@ function programChange(program: number): Uint8Array {
 
 // MIDI note numbers for common notes
 const C4 = 60;
+const D4 = 62;
 const E4 = 64;
+const Fs4 = 66;
 const G4 = 67;
 const A4 = 69;
 
@@ -141,6 +143,26 @@ describe('createWebMidiInput — binding', () => {
     input.fire(noteOn(E4, 80));
     expect(messages).toHaveLength(1);
   });
+
+  it("stop() restores the caller's pre-existing onmidimessage handler", () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    let priorCalls = 0;
+    const priorHandler = (): void => {
+      priorCalls += 1;
+    };
+    input.onmidimessage = priorHandler;
+
+    const controller = createWebMidiInput({ midiAccess: access });
+    // Our handler displaced the caller's while active.
+    expect(input.onmidimessage).not.toBe(priorHandler);
+
+    controller.stop();
+    // The caller's original handler is restored, not nulled.
+    expect(input.onmidimessage).toBe(priorHandler);
+    input.fire(noteOn(C4, 80));
+    expect(priorCalls).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -177,17 +199,6 @@ describe('createWebMidiInput — onMessage', () => {
     input2.fire(noteOn(E4, 80));
 
     expect(messages).toHaveLength(2);
-  });
-
-  it('skips null data without throwing', () => {
-    const input = makeFakeInput();
-    const access = makeFakeAccess([input]);
-    const messages: MidiMessage[] = [];
-
-    createWebMidiInput({ midiAccess: access, onMessage: (m) => messages.push(m) });
-
-    input.fire(null);
-    expect(messages).toHaveLength(0);
   });
 
   it('skips empty data (length 0) without throwing', () => {
@@ -456,20 +467,32 @@ describe('createWebMidiInput — onChord', () => {
 
     createWebMidiInput({ midiAccess: access, onChord: (c) => chords.push(c) });
 
-    // C major: C E G
+    // First chord — C major triad: C4 E4 G4 (root is the lowest sounding note).
     input.fire(noteOn(C4, 80));
     input.fire(noteOn(E4, 80));
     input.fire(noteOn(G4, 80));
 
-    const afterCMajor = chords.length;
+    const firstChord = chords.filter((c): c is Chord => c !== null).at(-1);
+    if (firstChord === undefined) throw new Error('expected a first chord to be detected.');
+    expect(firstChord.root.note).toBe('C');
+    expect(firstChord.suffix).toBe('major');
 
-    // Release G, add A → C minor 7th / Am
-    input.fire(noteOff(G4));
+    // Release the C major triad and play a D major triad: D4 F#4 A4.
+    input.fire(noteOff(C4));
     input.fire(noteOff(E4));
+    input.fire(noteOff(G4));
+    input.fire(noteOn(D4, 80));
+    input.fire(noteOn(Fs4, 80));
     input.fire(noteOn(A4, 80));
 
-    // Should have fired at least once more
-    expect(chords.length).toBeGreaterThan(afterCMajor);
+    // A non-null chord with a different identity must have been emitted.
+    const distinctSecond = chords
+      .filter((c): c is Chord => c !== null)
+      .find((c) => c.root.note !== firstChord.root.note || c.suffix !== firstChord.suffix);
+    expect(distinctSecond).toBeDefined();
+    if (distinctSecond === undefined) throw new Error('expected a distinct second chord.');
+    expect(distinctSecond.root.note).toBe('D');
+    expect(distinctSecond.suffix).toBe('major');
   });
 
   it('does NOT fire onChord when chord is unchanged', () => {

--- a/src/web-midi/web-midi-input.test.ts
+++ b/src/web-midi/web-midi-input.test.ts
@@ -277,6 +277,24 @@ describe('createWebMidiInput — onMessage', () => {
     expect(() => input.fire(new Uint8Array([0x40, 0x50]))).not.toThrow();
     expect(messages).toHaveLength(0);
   });
+
+  it('skips a channel-voice message that fails to parse, without throwing', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const messages: MidiMessage[] = [];
+    const controller = createWebMidiInput({
+      midiAccess: access,
+      onMessage: (m) => messages.push(m),
+    });
+
+    // Valid note-on status (0x90) but an out-of-range velocity (200) and a
+    // truncated note-on both make parseMidiMessage throw. The catch must skip
+    // them silently rather than letting the exception escape the handler.
+    expect(() => input.fire(new Uint8Array([0x90, 60, 200]))).not.toThrow();
+    expect(() => input.fire(new Uint8Array([0x90, 60]))).not.toThrow();
+    expect(messages).toHaveLength(0);
+    expect(controller.getNotes()).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/web-midi/web-midi-input.test.ts
+++ b/src/web-midi/web-midi-input.test.ts
@@ -22,6 +22,9 @@ import type { Chord } from '../chord.js';
 // Fake MIDIInput factory
 // ---------------------------------------------------------------------------
 
+/** A no-op handler used as an identity sentinel for "a foreign handler". */
+const interloper = (_event: MIDIMessageEventLike): void => {};
+
 function makeFakeInput(): MIDIInputLike & {
   fire(data: Uint8Array): void;
 } {
@@ -162,6 +165,40 @@ describe('createWebMidiInput — binding', () => {
     expect(input.onmidimessage).toBe(priorHandler);
     input.fire(noteOn(C4, 80));
     expect(priorCalls).toBe(1);
+  });
+
+  it('the bound handler is inert after stop(), even if invoked via a stale reference', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const messages: MidiMessage[] = [];
+
+    const controller = createWebMidiInput({
+      midiAccess: access,
+      onMessage: (m) => messages.push(m),
+    });
+    // Capture our handler reference before tearing down, then stop.
+    const ourHandler = input.onmidimessage;
+    expect(ourHandler).not.toBeNull();
+    controller.stop();
+
+    // Deliver a message directly to the stale handler reference. The internal
+    // `stopped` guard must make it a no-op (no torn-down state is touched).
+    if (ourHandler !== null) ourHandler({ data: noteOn(C4, 80) });
+    expect(messages).toHaveLength(0);
+    expect(controller.getNotes()).toHaveLength(0);
+  });
+
+  it('stop() does NOT clobber a handler that replaced ours after binding', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+
+    const controller = createWebMidiInput({ midiAccess: access });
+    // Someone (the caller) swaps in their own handler after we bound.
+    input.onmidimessage = interloper;
+
+    controller.stop();
+    // Teardown leaves the foreign handler alone rather than restoring our stale capture.
+    expect(input.onmidimessage).toBe(interloper);
   });
 });
 

--- a/src/web-midi/web-midi-input.test.ts
+++ b/src/web-midi/web-midi-input.test.ts
@@ -1,0 +1,542 @@
+/**
+ * Tests for createWebMidiInput.
+ *
+ * Uses explicitly-typed fake MIDIAccess / MIDIInput objects that implement the
+ * *Like interfaces. Mocks are typed as the interface, not `any`, so a wrong
+ * interface shape would be caught here rather than only by a real consumer.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { createWebMidiInput } from './web-midi-input.js';
+import type {
+  MIDIAccessLike,
+  MIDIInputLike,
+  MIDIMessageEventLike,
+  WebMidiInputController,
+} from './types.js';
+import type { MidiMessage } from '../midi/types.js';
+import type { Note } from '../note.js';
+import type { Chord } from '../chord.js';
+
+// ---------------------------------------------------------------------------
+// Fake MIDIInput factory
+// ---------------------------------------------------------------------------
+
+function makeFakeInput(): MIDIInputLike & {
+  fire(data: Uint8Array | null): void;
+} {
+  const fake = {
+    onmidimessage: null as ((event: MIDIMessageEventLike) => void) | null,
+    fire(data: Uint8Array | null): void {
+      const event: MIDIMessageEventLike = { data };
+      if (fake.onmidimessage !== null) {
+        fake.onmidimessage(event);
+      }
+    },
+  };
+  return fake;
+}
+
+function makeFakeAccess(inputs: MIDIInputLike[]): MIDIAccessLike {
+  return {
+    inputs: {
+      values(): IterableIterator<MIDIInputLike> {
+        return inputs[Symbol.iterator]();
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MIDI byte helpers
+// ---------------------------------------------------------------------------
+
+/** Note-On: channel 0, note, velocity */
+function noteOn(note: number, velocity: number): Uint8Array {
+  return new Uint8Array([0x90, note, velocity]);
+}
+
+/** Note-Off: channel 0, note */
+function noteOff(note: number): Uint8Array {
+  return new Uint8Array([0x80, note, 0]);
+}
+
+/** Control Change: channel 0, controller, value */
+function cc(controller: number, value: number): Uint8Array {
+  return new Uint8Array([0xb0, controller, value]);
+}
+
+/** Program Change: channel 0, program */
+function programChange(program: number): Uint8Array {
+  return new Uint8Array([0xc0, program]);
+}
+
+// MIDI note numbers for common notes
+const C4 = 60;
+const E4 = 64;
+const G4 = 67;
+const A4 = 69;
+
+// ---------------------------------------------------------------------------
+// Basic binding and teardown
+// ---------------------------------------------------------------------------
+
+describe('createWebMidiInput — binding', () => {
+  it('attaches onmidimessage to every input at creation', () => {
+    const input1 = makeFakeInput();
+    const input2 = makeFakeInput();
+    const access = makeFakeAccess([input1, input2]);
+
+    createWebMidiInput({ midiAccess: access });
+
+    expect(input1.onmidimessage).not.toBeNull();
+    expect(input2.onmidimessage).not.toBeNull();
+  });
+
+  it('stop() detaches handlers from all bound inputs', () => {
+    const input1 = makeFakeInput();
+    const input2 = makeFakeInput();
+    const access = makeFakeAccess([input1, input2]);
+
+    const controller = createWebMidiInput({ midiAccess: access });
+    controller.stop();
+
+    expect(input1.onmidimessage).toBeNull();
+    expect(input2.onmidimessage).toBeNull();
+  });
+
+  it('dispose() is an alias for stop()', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+
+    const controller = createWebMidiInput({ midiAccess: access });
+    controller.dispose();
+
+    expect(input.onmidimessage).toBeNull();
+  });
+
+  it('calling stop() twice is safe (no throw)', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+
+    const controller = createWebMidiInput({ midiAccess: access });
+    controller.stop();
+    expect(() => controller.stop()).not.toThrow();
+  });
+
+  it('messages received after stop() are ignored', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const messages: MidiMessage[] = [];
+
+    const controller = createWebMidiInput({
+      midiAccess: access,
+      onMessage: (m) => messages.push(m),
+    });
+
+    input.fire(noteOn(C4, 80));
+    expect(messages).toHaveLength(1);
+
+    controller.stop();
+    input.fire(noteOn(E4, 80));
+    expect(messages).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onMessage callback
+// ---------------------------------------------------------------------------
+
+describe('createWebMidiInput — onMessage', () => {
+  it('fires onMessage for every parsed message', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const messages: MidiMessage[] = [];
+
+    createWebMidiInput({ midiAccess: access, onMessage: (m) => messages.push(m) });
+
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOff(C4));
+    input.fire(cc(64, 127));
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0]?.type).toBe('noteOn');
+    expect(messages[1]?.type).toBe('noteOff');
+    expect(messages[2]?.type).toBe('controlChange');
+  });
+
+  it('fires onMessage for messages from multiple inputs', () => {
+    const input1 = makeFakeInput();
+    const input2 = makeFakeInput();
+    const access = makeFakeAccess([input1, input2]);
+    const messages: MidiMessage[] = [];
+
+    createWebMidiInput({ midiAccess: access, onMessage: (m) => messages.push(m) });
+
+    input1.fire(noteOn(C4, 80));
+    input2.fire(noteOn(E4, 80));
+
+    expect(messages).toHaveLength(2);
+  });
+
+  it('skips null data without throwing', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const messages: MidiMessage[] = [];
+
+    createWebMidiInput({ midiAccess: access, onMessage: (m) => messages.push(m) });
+
+    input.fire(null);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('skips empty data (length 0) without throwing', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const messages: MidiMessage[] = [];
+
+    createWebMidiInput({ midiAccess: access, onMessage: (m) => messages.push(m) });
+
+    input.fire(new Uint8Array([]));
+    expect(messages).toHaveLength(0);
+  });
+
+  it('skips system messages (status >= 0xF0) without throwing', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const messages: MidiMessage[] = [];
+
+    createWebMidiInput({ midiAccess: access, onMessage: (m) => messages.push(m) });
+
+    // 0xF0 = SysEx start; 0xF8 = timing clock; 0xFE = active sensing.
+    // All are valid MIDI but out of scope for the channel-voice adapter.
+    input.fire(new Uint8Array([0xf0, 0x41, 0xf7]));
+    input.fire(new Uint8Array([0xf8]));
+    input.fire(new Uint8Array([0xfe]));
+    expect(messages).toHaveLength(0);
+  });
+
+  it('skips a stray leading data byte (status < 0x80) without throwing', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const messages: MidiMessage[] = [];
+
+    createWebMidiInput({ midiAccess: access, onMessage: (m) => messages.push(m) });
+
+    // A first byte below 0x80 is a data byte, not a status byte — a running-
+    // status continuation or corruption this adapter does not reassemble.
+    // parseMidiMessage would throw; the guard must skip it silently instead.
+    expect(() => input.fire(new Uint8Array([0x40, 0x50]))).not.toThrow();
+    expect(messages).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onNote callback
+// ---------------------------------------------------------------------------
+
+describe('createWebMidiInput — onNote', () => {
+  it('fires onNote with note and message for noteOn', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const notes: Array<{ note: Note; message: MidiMessage }> = [];
+
+    createWebMidiInput({
+      midiAccess: access,
+      onNote: (note, message) => notes.push({ note, message }),
+    });
+
+    input.fire(noteOn(C4, 80));
+
+    expect(notes).toHaveLength(1);
+    const first = notes[0];
+    if (first === undefined) throw new Error('expected a note event.');
+    expect(first.note.midi).toBe(C4);
+    expect(first.message.type).toBe('noteOn');
+  });
+
+  it('fires onNote with note and message for noteOff', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const notes: Array<{ note: Note; message: MidiMessage }> = [];
+
+    createWebMidiInput({
+      midiAccess: access,
+      onNote: (note, message) => notes.push({ note, message }),
+    });
+
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOff(C4));
+
+    expect(notes).toHaveLength(2);
+    expect(notes[1]?.message.type).toBe('noteOff');
+  });
+
+  it('does NOT fire onNote for non-note messages (programChange)', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const notes: Note[] = [];
+
+    createWebMidiInput({
+      midiAccess: access,
+      onNote: (note) => notes.push(note),
+    });
+
+    input.fire(programChange(10));
+    expect(notes).toHaveLength(0);
+  });
+
+  it('does NOT fire onNote for control change messages', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const notes: Note[] = [];
+
+    createWebMidiInput({
+      midiAccess: access,
+      onNote: (note) => notes.push(note),
+    });
+
+    input.fire(cc(7, 100));
+    expect(notes).toHaveLength(0);
+  });
+
+  it('respects accidentalPreference for note spelling', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const notes: Note[] = [];
+
+    // A#4 / Bb4 = MIDI 70
+    createWebMidiInput({
+      midiAccess: access,
+      accidentalPreference: 'flats',
+      onNote: (note) => notes.push(note),
+    });
+
+    input.fire(noteOn(70, 80));
+    expect(notes[0]?.note).toBe('Bb');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Active-note state (getNotes / getChord)
+// ---------------------------------------------------------------------------
+
+describe('createWebMidiInput — getNotes', () => {
+  it('returns empty array when no notes are held', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const controller = createWebMidiInput({ midiAccess: access });
+
+    expect(controller.getNotes()).toHaveLength(0);
+  });
+
+  it('tracks held notes after noteOn', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const controller = createWebMidiInput({ midiAccess: access });
+
+    input.fire(noteOn(C4, 80));
+    const notes = controller.getNotes();
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.midi).toBe(C4);
+  });
+
+  it('removes notes after noteOff', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const controller = createWebMidiInput({ midiAccess: access });
+
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOff(C4));
+
+    expect(controller.getNotes()).toHaveLength(0);
+  });
+
+  it('tracks multiple held notes', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const controller = createWebMidiInput({ midiAccess: access });
+
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOn(E4, 80));
+    input.fire(noteOn(G4, 80));
+
+    expect(controller.getNotes()).toHaveLength(3);
+  });
+});
+
+describe('createWebMidiInput — getChord', () => {
+  it('returns null when no notes are held', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const controller = createWebMidiInput({ midiAccess: access });
+
+    expect(controller.getChord()).toBeNull();
+  });
+
+  it('returns null with only one note', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const controller = createWebMidiInput({ midiAccess: access });
+
+    input.fire(noteOn(C4, 80));
+    expect(controller.getChord()).toBeNull();
+  });
+
+  it('identifies a C major chord (C E G)', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const controller = createWebMidiInput({ midiAccess: access });
+
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOn(E4, 80));
+    input.fire(noteOn(G4, 80));
+
+    const chord = controller.getChord();
+    expect(chord).not.toBeNull();
+    expect(chord?.root.note).toBe('C');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onChord callback — change detection
+// ---------------------------------------------------------------------------
+
+describe('createWebMidiInput — onChord', () => {
+  it('fires onChord when a chord becomes detectable (null → chord)', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const chords: Array<Chord | null> = [];
+
+    createWebMidiInput({ midiAccess: access, onChord: (c) => chords.push(c) });
+
+    // Single note — no chord yet
+    input.fire(noteOn(C4, 80));
+    expect(chords).toHaveLength(0);
+
+    // Second note — still no known chord (C + E is not a catalogued chord by itself)
+    input.fire(noteOn(E4, 80));
+
+    // Third note — C major chord
+    input.fire(noteOn(G4, 80));
+
+    const lastChord = chords.at(-1);
+    if (lastChord === null || lastChord === undefined) {
+      throw new Error('expected a chord to be detected.');
+    }
+    expect(lastChord.root.note).toBe('C');
+  });
+
+  it('fires onChord when chord clears (chord → null)', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const chords: Array<Chord | null> = [];
+
+    createWebMidiInput({ midiAccess: access, onChord: (c) => chords.push(c) });
+
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOn(E4, 80));
+    input.fire(noteOn(G4, 80));
+
+    const beforeRelease = chords.length;
+
+    input.fire(noteOff(G4));
+    input.fire(noteOff(E4));
+    input.fire(noteOff(C4));
+
+    // At least one null emission after all notes released
+    const nulls = chords.slice(beforeRelease).filter((c) => c === null);
+    expect(nulls.length).toBeGreaterThan(0);
+  });
+
+  it('fires onChord when chord changes (chord → different chord)', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const chords: Array<Chord | null> = [];
+
+    createWebMidiInput({ midiAccess: access, onChord: (c) => chords.push(c) });
+
+    // C major: C E G
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOn(E4, 80));
+    input.fire(noteOn(G4, 80));
+
+    const afterCMajor = chords.length;
+
+    // Release G, add A → C minor 7th / Am
+    input.fire(noteOff(G4));
+    input.fire(noteOff(E4));
+    input.fire(noteOn(A4, 80));
+
+    // Should have fired at least once more
+    expect(chords.length).toBeGreaterThan(afterCMajor);
+  });
+
+  it('does NOT fire onChord when chord is unchanged', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const chords: Array<Chord | null> = [];
+
+    createWebMidiInput({ midiAccess: access, onChord: (c) => chords.push(c) });
+
+    // C major
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOn(E4, 80));
+    input.fire(noteOn(G4, 80));
+
+    const countAfterChord = chords.length;
+
+    // Add C4 again (already held) — state does not change, chord does not change
+    input.fire(noteOn(C4, 80));
+
+    expect(chords.length).toBe(countAfterChord);
+  });
+
+  it('passes null to onChord when no notes are held (no chord detected)', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const chords: Array<Chord | null> = [];
+
+    createWebMidiInput({ midiAccess: access, onChord: (c) => chords.push(c) });
+
+    // Build and fully release a C major chord
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOn(E4, 80));
+    input.fire(noteOn(G4, 80));
+    input.fire(noteOff(C4));
+    input.fire(noteOff(E4));
+    input.fire(noteOff(G4));
+
+    const hasNull = chords.some((c) => c === null);
+    expect(hasNull).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No callbacks provided — still tracks state
+// ---------------------------------------------------------------------------
+
+describe('createWebMidiInput — no callbacks', () => {
+  it('works without any callback options', () => {
+    const input = makeFakeInput();
+    const access = makeFakeAccess([input]);
+    const controller: WebMidiInputController = createWebMidiInput({ midiAccess: access });
+
+    input.fire(noteOn(C4, 80));
+    input.fire(noteOn(E4, 80));
+    input.fire(noteOn(G4, 80));
+
+    expect(controller.getNotes()).toHaveLength(3);
+    const chord = controller.getChord();
+    expect(chord).not.toBeNull();
+  });
+
+  it('handles empty inputs map gracefully', () => {
+    const access = makeFakeAccess([]);
+    const controller = createWebMidiInput({ midiAccess: access });
+
+    expect(controller.getNotes()).toHaveLength(0);
+    expect(controller.getChord()).toBeNull();
+    expect(() => controller.stop()).not.toThrow();
+  });
+});

--- a/src/web-midi/web-midi-input.ts
+++ b/src/web-midi/web-midi-input.ts
@@ -178,15 +178,23 @@ export function createWebMidiInput(options: WebMidiInputOptions): WebMidiInputCo
 
   // Capture inputs at creation time, each paired with the handler it had before
   // we bound ours, so teardown can RESTORE the caller's prior handler rather
-  // than clobbering it — the MIDIAccess is caller-owned and may be shared.
-  // Hot-plug (ports added after creation) is explicitly out of scope for v1.
+  // than clobbering it — the MIDIAccess is caller-owned.
+  //
+  // Ownership model (v1): ONE controller per MIDIInput. Binding two controllers
+  // to the same input concurrently, and hot-plug (ports added after creation),
+  // are out of scope. A stopped controller is always inert (the `stopped` guard
+  // below) and never clobbers a handler that is not ours (the teardown check).
   const boundInputs: Array<{
     input: MIDIInputLike;
     previous: ((event: MIDIMessageEventLike) => void) | null;
   }> = [];
 
-  // The single handler shared across all bound inputs.
+  let stopped = false;
+
+  // The single handler shared across all bound inputs. Inert once stopped, so a
+  // late message delivered to a stale reference cannot reach a torn-down state.
   const handleMessage = (event: MIDIMessageEventLike): void => {
+    if (stopped) return;
     const result = processMessageEvent(
       event,
       state,
@@ -206,14 +214,16 @@ export function createWebMidiInput(options: WebMidiInputOptions): WebMidiInputCo
     input.onmidimessage = handleMessage;
   }
 
-  // Teardown: restore each input's prior handler (null when there was none).
-  let stopped = false;
-
+  // Teardown: restore each input's prior handler — but only where ours is still
+  // attached. If the caller (or anyone) replaced the handler after we bound,
+  // leave their handler in place rather than clobbering it with a stale capture.
   function stop(): void {
     if (stopped) return;
     stopped = true;
     for (const { input, previous } of boundInputs) {
-      input.onmidimessage = previous;
+      if (input.onmidimessage === handleMessage) {
+        input.onmidimessage = previous;
+      }
     }
   }
 

--- a/src/web-midi/web-midi-input.ts
+++ b/src/web-midi/web-midi-input.ts
@@ -1,0 +1,232 @@
+/**
+ * Browser Web MIDI adapter — subscribe to a caller-owned MIDIAccess and
+ * receive parsed MIDI messages, note transitions, and chord changes.
+ *
+ * ALL browser globals come from the caller via options. Nothing at module
+ * scope touches `navigator`, `window`, `MIDIAccess`, or any other browser
+ * global — the module is safe to import in non-browser environments (Bun,
+ * Node) without throwing.
+ */
+
+import type { Note } from '../note.js';
+import type { Chord } from '../chord.js';
+import {
+  parseMidiMessage,
+  createMidiState,
+  applyMidiMessage,
+  notesFromActiveMidiState,
+  chordFromActiveMidiState,
+  messageToNote,
+} from '../midi/index.js';
+import type { MidiState } from '../midi/state.js';
+import type { MidiMessage } from '../midi/types.js';
+import type {
+  MIDIInputLike,
+  MIDIMessageEventLike,
+  OnChordCallback,
+  OnMessageCallback,
+  OnNoteCallback,
+  WebMidiInputController,
+  WebMidiInputOptions,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a stable string key for chord-change detection.
+ * Combines root note name, octave, and suffix to identify the exact chord.
+ */
+function chordKey(chord: Chord): string {
+  return `${chord.root.note}${chord.suffix}:${chord.inversionIndex}`;
+}
+
+/**
+ * Fires the onChord callback when the current chord differs from the previous.
+ *
+ * Handles all transitions:
+ * - null → chord (new chord detected)
+ * - chord → different chord (chord changed)
+ * - chord → null (all notes released / chord no longer identifiable)
+ * - chord → same chord (suppressed — no fire)
+ */
+function maybeFireChordChange(
+  current: Chord | null,
+  previous: Chord | null,
+  onChord: OnChordCallback,
+): void {
+  const currentKey = current === null ? null : chordKey(current);
+  const previousKey = previous === null ? null : chordKey(previous);
+
+  if (currentKey !== previousKey) {
+    onChord(current);
+  }
+}
+
+// Channel-voice status bytes occupy 0x80–0xEF. A valid first byte must be a
+// status byte (high bit set, i.e. >= 0x80) below the system range (< 0xF0):
+//   - bytes < 0x80 are data bytes (a stray leading data byte — running-status
+//     continuation or corruption — that this adapter does not reassemble);
+//   - bytes >= 0xF0 are system messages (SysEx, timing clock, active sensing).
+// Both are out of scope; parseMidiMessage throws for them, so we skip them
+// explicitly here rather than letting an exception escape the message handler.
+const CHANNEL_VOICE_STATUS_MIN = 0x80;
+const SYSTEM_MESSAGE_THRESHOLD = 0xf0;
+
+/**
+ * Processes a raw MIDI message event: parses the bytes, updates state, and
+ * fires caller callbacks.
+ *
+ * Only channel-voice messages (status byte 0x80–0xEF) are dispatched.
+ * Null/empty data, stray data bytes (< 0x80), and system messages (>= 0xF0)
+ * are silently skipped.
+ *
+ * Returns the new state after applying the message.
+ */
+function processMessageEvent(
+  event: MIDIMessageEventLike,
+  state: MidiState,
+  previousChord: Chord | null,
+  accidentalPreference: 'sharps' | 'flats',
+  onMessage: OnMessageCallback | undefined,
+  onNote: OnNoteCallback | undefined,
+  onChord: OnChordCallback | undefined,
+): { state: MidiState; chord: Chord | null } {
+  // Guard: skip null data (some browsers emit events with null data).
+  if (event.data === null) {
+    return { state, chord: previousChord };
+  }
+
+  // Guard: skip anything that is not a channel-voice status byte. Empty data
+  // (undefined first byte), stray data bytes (< 0x80), and system messages
+  // (>= 0xF0) are all out of scope; parseMidiMessage would throw for them.
+  const status = event.data[0];
+  if (
+    status === undefined ||
+    status < CHANNEL_VOICE_STATUS_MIN ||
+    status >= SYSTEM_MESSAGE_THRESHOLD
+  ) {
+    return { state, chord: previousChord };
+  }
+
+  const parsed: MidiMessage = parseMidiMessage(event.data);
+
+  // Fire onMessage for every successfully-parsed message.
+  onMessage?.(parsed);
+
+  // Advance the active-note state.
+  const nextState = applyMidiMessage(state, parsed);
+
+  // Fire onNote for note-bearing messages.
+  if (onNote !== undefined) {
+    const note: Note | null = messageToNote(parsed, { accidentalPreference });
+    if (note !== null) {
+      onNote(note, parsed);
+    }
+  }
+
+  // Fire onChord when the chord changes.
+  if (onChord !== undefined) {
+    const currentChord: Chord | null = chordFromActiveMidiState(nextState, {
+      accidentalPreference,
+    });
+    maybeFireChordChange(currentChord, previousChord, onChord);
+    return { state: nextState, chord: currentChord };
+  }
+
+  return { state: nextState, chord: previousChord };
+}
+
+// ---------------------------------------------------------------------------
+// createWebMidiInput
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a Web MIDI input controller that subscribes to all inputs on the
+ * provided `midiAccess` object.
+ *
+ * At creation time the controller iterates `midiAccess.inputs.values()` and
+ * attaches an `onmidimessage` handler to every port. Incoming messages are
+ * parsed with the MIDI helpers from `octavian/midi`, folded into an
+ * active-note state, and dispatched to the caller-supplied callbacks.
+ *
+ * The controller is safe to import in non-browser environments — no browser
+ * globals are referenced at module scope. All runtime objects come from
+ * the caller via `options`.
+ *
+ * @example
+ * ```ts
+ * const access = await navigator.requestMIDIAccess();
+ * const controller = createWebMidiInput({
+ *   midiAccess: access,
+ *   onNote: (note, msg) => console.log(msg.type, note.name),
+ *   onChord: (chord) => console.log(chord?.name ?? 'no chord'),
+ * });
+ *
+ * // Later:
+ * controller.stop();
+ * ```
+ *
+ * @param options Configuration including the MIDIAccess object and callbacks.
+ * @returns A {@link WebMidiInputController} for querying state and stopping.
+ */
+export function createWebMidiInput(options: WebMidiInputOptions): WebMidiInputController {
+  const { midiAccess, onMessage, onNote, onChord } = options;
+  const accidentalPreference: 'sharps' | 'flats' = options.accidentalPreference ?? 'sharps';
+
+  // Active-note state — updated on every incoming message.
+  let state: MidiState = createMidiState();
+
+  // Last chord seen — used for change-detection in onChord.
+  let lastChord: Chord | null = null;
+
+  // Capture inputs at creation time into a stable array for PINNED teardown.
+  // Hot-plug (ports added after creation) is explicitly out of scope for v1.
+  const boundInputs: MIDIInputLike[] = [];
+
+  // The single handler shared across all bound inputs.
+  const handleMessage = (event: MIDIMessageEventLike): void => {
+    const result = processMessageEvent(
+      event,
+      state,
+      lastChord,
+      accidentalPreference,
+      onMessage,
+      onNote,
+      onChord,
+    );
+    state = result.state;
+    lastChord = result.chord;
+  };
+
+  // Bind to every input available at creation time.
+  for (const input of midiAccess.inputs.values()) {
+    input.onmidimessage = handleMessage;
+    boundInputs.push(input);
+  }
+
+  // Teardown: detach from every input that was bound at creation.
+  let stopped = false;
+
+  function stop(): void {
+    if (stopped) return;
+    stopped = true;
+    for (const input of boundInputs) {
+      input.onmidimessage = null;
+    }
+  }
+
+  return {
+    getNotes(): readonly Note[] {
+      return notesFromActiveMidiState(state, { accidentalPreference });
+    },
+
+    getChord(): Chord | null {
+      return chordFromActiveMidiState(state, { accidentalPreference });
+    },
+
+    stop,
+    dispose: stop,
+  };
+}

--- a/src/web-midi/web-midi-input.ts
+++ b/src/web-midi/web-midi-input.ts
@@ -79,7 +79,7 @@ const SYSTEM_MESSAGE_THRESHOLD = 0xf0;
  * fires caller callbacks.
  *
  * Only channel-voice messages (status byte 0x80–0xEF) are dispatched.
- * Null/empty data, stray data bytes (< 0x80), and system messages (>= 0xF0)
+ * Empty data, stray data bytes (< 0x80), and system messages (>= 0xF0)
  * are silently skipped.
  *
  * Returns the new state after applying the message.
@@ -93,11 +93,6 @@ function processMessageEvent(
   onNote: OnNoteCallback | undefined,
   onChord: OnChordCallback | undefined,
 ): { state: MidiState; chord: Chord | null } {
-  // Guard: skip null data (some browsers emit events with null data).
-  if (event.data === null) {
-    return { state, chord: previousChord };
-  }
-
   // Guard: skip anything that is not a channel-voice status byte. Empty data
   // (undefined first byte), stray data bytes (< 0x80), and system messages
   // (>= 0xF0) are all out of scope; parseMidiMessage would throw for them.
@@ -181,9 +176,14 @@ export function createWebMidiInput(options: WebMidiInputOptions): WebMidiInputCo
   // Last chord seen — used for change-detection in onChord.
   let lastChord: Chord | null = null;
 
-  // Capture inputs at creation time into a stable array for PINNED teardown.
+  // Capture inputs at creation time, each paired with the handler it had before
+  // we bound ours, so teardown can RESTORE the caller's prior handler rather
+  // than clobbering it — the MIDIAccess is caller-owned and may be shared.
   // Hot-plug (ports added after creation) is explicitly out of scope for v1.
-  const boundInputs: MIDIInputLike[] = [];
+  const boundInputs: Array<{
+    input: MIDIInputLike;
+    previous: ((event: MIDIMessageEventLike) => void) | null;
+  }> = [];
 
   // The single handler shared across all bound inputs.
   const handleMessage = (event: MIDIMessageEventLike): void => {
@@ -200,20 +200,20 @@ export function createWebMidiInput(options: WebMidiInputOptions): WebMidiInputCo
     lastChord = result.chord;
   };
 
-  // Bind to every input available at creation time.
+  // Bind to every input available at creation time, remembering its prior handler.
   for (const input of midiAccess.inputs.values()) {
+    boundInputs.push({ input, previous: input.onmidimessage });
     input.onmidimessage = handleMessage;
-    boundInputs.push(input);
   }
 
-  // Teardown: detach from every input that was bound at creation.
+  // Teardown: restore each input's prior handler (null when there was none).
   let stopped = false;
 
   function stop(): void {
     if (stopped) return;
     stopped = true;
-    for (const input of boundInputs) {
-      input.onmidimessage = null;
+    for (const { input, previous } of boundInputs) {
+      input.onmidimessage = previous;
     }
   }
 

--- a/src/web-midi/web-midi-input.ts
+++ b/src/web-midi/web-midi-input.ts
@@ -36,7 +36,11 @@ import type {
 
 /**
  * Returns a stable string key for chord-change detection.
- * Combines root note name, octave, and suffix to identify the exact chord.
+ *
+ * Combines the root pitch class, suffix, and inversion — deliberately NOT the
+ * root octave: re-voicing the same chord quality an octave higher requires
+ * releasing the bass, which passes through a no-chord (null) state and so
+ * already re-fires `onChord` on the way back up.
  */
 function chordKey(chord: Chord): string {
   return `${chord.root.note}${chord.suffix}:${chord.inversionIndex}`;
@@ -79,8 +83,9 @@ const SYSTEM_MESSAGE_THRESHOLD = 0xf0;
  * fires caller callbacks.
  *
  * Only channel-voice messages (status byte 0x80–0xEF) are dispatched.
- * Empty data, stray data bytes (< 0x80), and system messages (>= 0xF0)
- * are silently skipped.
+ * Empty data, stray data bytes (< 0x80), system messages (>= 0xF0), and
+ * messages that fail to parse (out-of-range data bytes, truncated) are
+ * silently skipped — no exception escapes the caller's onmidimessage handler.
  *
  * Returns the new state after applying the message.
  */
@@ -105,7 +110,18 @@ function processMessageEvent(
     return { state, chord: previousChord };
   }
 
-  const parsed: MidiMessage = parseMidiMessage(event.data);
+  // A well-formed status byte can still carry out-of-range data bytes (e.g.
+  // velocity 200) or be truncated, both of which make parseMidiMessage throw.
+  // Skip such messages silently — consistent with the other out-of-scope skips —
+  // rather than letting an exception escape the caller's onmidimessage handler.
+  // The catch is scoped to the parse ONLY: a throw from a consumer callback below
+  // must still surface to the consumer.
+  let parsed: MidiMessage;
+  try {
+    parsed = parseMidiMessage(event.data);
+  } catch {
+    return { state, chord: previousChord };
+  }
 
   // Fire onMessage for every successfully-parsed message.
   onMessage?.(parsed);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -14,6 +14,8 @@ export default defineConfig({
     'src/midi/index.ts',
     'src/midi-file/index.ts',
     'src/performance-timing/index.ts',
+    'src/web-audio/index.ts',
+    'src/web-midi/index.ts',
   ],
   outDir: 'dist/browser',
   format: 'esm',


### PR DESCRIPTION
## Summary

Wave D, part 2 (the final feature PR): two **browser-only adapter** subpath exports for `octavian`. Both accept caller-provided runtime objects (no global audio/MIDI state), reference no browser globals at import time, and keep the root export pure.

Closes #32 and the browser-adapter portion of #31. (The `octavian/midi` message layer from #31 shipped in PR #44.)

### The modules

- **`octavian/web-audio`** (#32) — `createWebAudioRenderer({ audioContext, tuning? })` returning a renderer with `scheduleNote` / `scheduleChord` / `scheduleSequence` / `renderOffline`. Oscillator + gain voices are scheduled on the caller-provided `AudioContext` using `currentTime`-based timing (not app timers); `renderOffline` takes a caller-provided `OfflineAudioContext`. A simple attack envelope is supported, clamped to the note end so a degenerate `attack >= duration` can't mis-order the gain automation. Note→frequency via `note.frequency` or `noteToFrequency(note, tuning)`.
- **`octavian/web-midi`** (#31 adapter) — `createWebMidiInput({ midiAccess, onMessage?, onNote?, onChord?, accidentalPreference? })` returning a controller that subscribes to every input on the caller-owned `MIDIAccess`, parses incoming bytes through `octavian/midi`, tracks active-note state, and fires callbacks. `getNotes()` / `getChord()` query state; `stop()` / `dispose()` tear down.

### Design notes

- **No DOM lib.** `tsconfig` `lib` is `["ESNext"]`, so the adapters declare minimal **structural `*Like` interfaces** (only the members called, MDN-accurate signatures) instead of pulling in DOM types. Nothing references a browser global at import time — the Bun tarball smoke test imports both subpaths and asserts they load + export their factory (existence-only).
- **Input validation** mirrors the rest of the library: velocity must be an integer `1..127` (`TypeError` non-integer, `RangeError` out of range); `duration` finite `> 0`, `startTime` finite, `attack` finite `>= 0` (`RangeError`). Velocity `0` is note-off and rejected.
- **web-midi ownership model (v1):** one controller per `MIDIInput`. `stop()` restores each input's prior `onmidimessage` handler (rather than nulling it), but only where ours is still attached — a stopped controller is always inert and never clobbers a foreign handler. Concurrent controllers on the same input, and hot-plug (ports added after creation), are out of scope for v1.

### Build wiring

Two `tsdown.config.ts` entries, two `"./web-audio"` + `"./web-midi"` blocks in the `package.json` exports map (types-first), and two existence-only assertions in `scripts/smoke-checks.mjs` exercised by the tarball smoke test. The root `src/index.ts` re-exports neither (isolation preserved).

## Known follow-up (flagged, not deferred)

Issue #32 also lists *caller-provided sample buffers / instrument callbacks*. This baseline ships oscillator-only voices; the instrument-callback hook is a genuine additive (non-breaking) follow-up, not part of this PR.

## Verification

- `bun run validate` green: format, lint, typecheck, typecheck:test, **2633 tests**, build, `publint` + `attw` (all 9 exports 🟢 for node16-ESM and bundler), artifact validation across all 16 browser bundles (no Node/Bun globals, no bare specifiers, no `<reference>` directives), and the **tarball smoke test** — both adapter subpaths imported under Bun without throwing (the real proof of no import-time browser globals).
- Non-parallel coverage: `src/web-audio/renderer.ts`, `src/web-audio/index.ts`, `src/web-midi/web-midi-input.ts` all at **100% line + function**. (The `types.ts` files and `web-midi/index.ts` are type-only / barrel — no executable lines.)

## Review committee

Built each module in an isolated worktree with an adversarial verifier, then ran the full committee before opening this PR. The Claude subagent dispatches hit the known `/usage-credits` (1M-context) error, so all four personas were reviewed via Codex (`codex-review.sh`, medium) plus the mandatory primary Codex reviewer (xhigh → high across rounds). Three rounds; consensus reached. The committee caught a stack of real issues that had passed the per-module 100%-coverage tests:

- **Inputs unvalidated beyond velocity-0** (primary Codex + testing-expert, must-fix) — velocity `-1` / `128` / non-integer, and non-finite / non-positive `duration` / `startTime` / `attack` all slipped through while the JSDoc promised `1..127` / `attack >= 0`. Now validated at single chokepoints (`resolveVelocity`, `validateVoiceTiming`), covering note/chord/sequence.
- **`stop()` clobbered the caller's MIDI handler** (Codex, must-fix) → restore-on-teardown; then **restore could break the "inert after stop()" contract for a displaced handler** (Codex round 2, must-fix) → a `stopped` guard inside the handler + restore-only-if-ours, with the v1 ownership boundary documented.
- **`MIDIMessageEventLike.data` typed `Uint8Array | null`** (Codex + typescript-expert) → non-null `Uint8Array` per the Web MIDI spec.
- **`onChord` "different chord" test only asserted a length increase** (testing-expert, must-fix) → now asserts two distinct non-null chords (C major → D major), verified against the real chord-detection behavior.

`simplicity-engineer`'s "remove `renderOffline` / `Envelope`" was overruled — both are explicit acceptance criteria in #32. `dx-engineer` approved the build wiring.

## Test plan

`bun run validate` from a clean checkout. To exercise the adapters in a browser, pass a real `AudioContext` to `createWebAudioRenderer` / a `MIDIAccess` from `navigator.requestMIDIAccess()` to `createWebMidiInput`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
