### PR TITLE
chore: release 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octavian",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Type-safe music theory utilities for notes, intervals, chords, and scales.",
   "keywords": [
     "music-theory",


### PR DESCRIPTION
## Summary

Minor release bumping `package.json` from `3.0.0` → `3.1.0`. All changes since 3.0.0 are **additive** — new browser-safe subpath exports, no breaking changes to the root API — so this is a minor bump per semver.

Shipped since 3.0.0:
- `octavian/sequences`, `octavian/notation`, `octavian/pitch`, `octavian/midi`, `octavian/midi-file`, `octavian/perf-timing` (#44)
- `octavian/web-audio`, `octavian/web-midi` browser adapters (#45)

This completes the drain of GitHub issues #17–#38 (all closed).

## Release mechanism

Merging this lands the version bump on `main`. The tag `v3.1.0` (pushed after merge) triggers `.github/workflows/release.yaml`: `verify-release-version` (tag ↔ package.json) → build → `package:check` → `npm publish` with OIDC trusted publishing + provenance.

## Verification

This PR is a single-line version bump (`3.0.0` → `3.1.0`); the code it releases was reviewed and merged in #44 and #45. `bun run validate` is green on this branch (2634 tests, all 16 bundles, `publint` + `attw` 🟢 for all 9 exports, tarball smoke). `verify-release-version.ts --tag=v3.1.0` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)